### PR TITLE
Fix links and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 **/*.eml
 *.ipr
 *.iws
+*.yaml-e

--- a/Makefile
+++ b/Makefile
@@ -103,11 +103,11 @@ build: generate fmt vet manifests
 	go build -o bin/manager ./cmd/manager/main.go
 	GOOS=linux GOARCH=amd64 go build \
 	     -o bin/kubectl/kubectl-hns_linux_amd64 \
-	     -ldflags="-X sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version.Version=${HNC_IMG_TAG}" \
+	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
 	     ./cmd/kubectl/main.go
 	GOOS=darwin GOARCH=amd64 go build \
 	     -o bin/kubectl/kubectl-hns_darwin_amd64 \
-	     -ldflags="-X sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version.Version=${HNC_IMG_TAG}" \
+	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
 	     ./cmd/kubectl/main.go
 
 # Clean all binaries (manager and kubectl)
@@ -348,7 +348,7 @@ release: check-release-env
 	@echo "Releasing ${HNC_RELEASE_IMG}"
 	@echo "... override with HNC_RELEASE_REGISTRY, HNC_IMG_NAME and"
 	@echo "... HNC_IMG_TAG."
-	@echo "Pulling from Github multi-tenancy repo owned by ${HNC_RELEASE_REPO_OWNER}"
+	@echo "Pulling from Github hierarchical-namespaces repo owned by ${HNC_RELEASE_REPO_OWNER}"
 	@echo "... override with HNC_RELEASE_REPO_OWNER"
 	@echo "GCP project: ${PROJECT_ID} (obtained from gcloud)"
 	@echo "Temporary build image (must be in ${PROJECT_ID}): ${HNC_IMG}"

--- a/PROJECT
+++ b/PROJECT
@@ -1,6 +1,6 @@
 version: "2"
 domain: x-k8s.io
-repo: github.com/kubernetes-sigs/multi-tenancy
+repo: github.com/kubernetes-sigs/hierarchical-namespaces
 resources:
 - group: hnc
   version: v1alpha1

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All HNC issues are assigned to an HNC milestone. So far, the following
 milestones are defined or planned:
 
 * v1.0 - Likely late Q2 or early Q3 2021: HNC recommended for production use
-* [v0.9](https://github.com/kubernetes-sigs/multi-tenancy/milestone/21): move
+* [v0.9](https://github.com/kubernetes-sigs/hierarchical-namespaces/milestone/21): move
   HNC to its own repo; continued stability improvements.
 * [v0.8 - COMPLETE APR 2021](https://github.com/kubernetes-sigs/multi-tenancy/milestone/20):
   incremental stability improvements
@@ -73,7 +73,7 @@ milestones are defined or planned:
 * [v0.1 - COMPLETE NOV 2019](https://github.com/kubernetes-sigs/multi-tenancy/milestone/7):
   an initial release with all basic functionality so you can play with it, but
   not suitable for any real workloads.
-* [Backlog](https://github.com/kubernetes-sigs/multi-tenancy/milestone/9):
+* [Backlog](https://github.com/kubernetes-sigs/hierarchical-namespaces/milestone/9):
   all unscheduled work.
 
 ## Contributing to HNC
@@ -158,8 +158,6 @@ cycle looks like the following:
       stored on Github) or the _full_ path to the local manifests. If these are
       not set, we'll skip any tests that include modifying the HNC deployement,
       e.g. to bypass webhooks.
-    - If you deploy to Kind, the tests that use Network Policies may fail. See
-      https://github.com/kubernetes-sigs/multi-tenancy/issues/1098.
   - Once you're ready to make a pull request, please follow the following
     instructions:
     - Each PR should contain _one commit_. If you have multiple commits (either
@@ -168,7 +166,7 @@ cycle looks like the following:
       any changes to your fork of this repo.
     - Ensure your commit message includes a "Tested:" section explaining in
       reasonable detail what you did to test your change.
-      [Here](https://github.com/kubernetes-sigs/multi-tenancy/commit/ce983662e87264c76f92dbfbab7cef7bd6128837)
+      [Here](https://github.com/kubernetes-sigs/hierarchical-namespaces/commit/ce983662e87264c76f92dbfbab7cef7bd6128837)
       is a good example. A minimal message might be something like "Added new
       test; verified that the test failed before my change and passed after it;
       ran e2e tests."

--- a/api/v1alpha2/hnc_config.go
+++ b/api/v1alpha2/hnc_config.go
@@ -144,7 +144,7 @@ type HNCConfigurationSpec struct {
 	// Note that 'roles' and 'rolebindings' are pre-configured by HNC with
 	// 'Propagate' mode and are omitted in the spec. Any configuration of 'roles'
 	// or 'rolebindings' are not allowed. To learn more, see
-	// https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/how-to.md#admin-types
+	// https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#admin-types
 	Resources []ResourceSpec `json:"resources,omitempty"`
 }
 
@@ -157,7 +157,7 @@ type HNCConfigurationStatus struct {
 	// "ActivitiesHalted" reason, this means that HNC cannot function in the
 	// affected namespaces. The HierarchyConfiguration object in each of the
 	// affected namespaces will have more information. To learn more about
-	// conditions, see https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/concepts.md#admin-conditions.
+	// conditions, see https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/concepts.md#admin-conditions.
 	Conditions []Condition `json:"conditions,omitempty"`
 }
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,9 +7,9 @@ steps:
   - '-c'
   - |
     set -e
-    echo Cloning from https://github.com/$_HNC_REPO_OWNER/multi-tenancy
-    git clone https://github.com/$_HNC_REPO_OWNER/multi-tenancy
-    cd multi-tenancy
+    echo Cloning from https://github.com/$_HNC_REPO_OWNER/hierarchical-namespaces
+    git clone https://github.com/$_HNC_REPO_OWNER/hierarchical-namespaces
+    cd hierarchical-namespaces
     echo Checking out hnc-$_HNC_IMG_TAG
     git checkout hnc-$_HNC_IMG_TAG
 # Build the manifests and the kubectl plugin
@@ -19,7 +19,7 @@ steps:
   - '-c'
   - |
     set -e
-    cd multi-tenancy/incubator/hnc
+    cd hierarchical-namespaces
     export HNC_REGISTRY=$_HNC_REGISTRY
     export HNC_IMG_NAME=$_HNC_IMG_NAME
     export HNC_IMG_TAG=$_HNC_IMG_TAG
@@ -35,10 +35,10 @@ steps:
   - '-H'
   - 'Content-Type: application/x-application'
   - '--data-binary'
-  - '@multi-tenancy/incubator/hnc/manifests/hnc-manager.yaml'
+  - '@hierarchical-namespaces/manifests/hnc-manager.yaml'
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
-  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=hnc-manager.yaml'
+  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/hierarchical-namespaces/releases/$_HNC_RELEASE_ID/assets?name=hnc-manager.yaml'
 # Upload plugin (Linux)
 - name: gcr.io/cloud-builders/curl
   args:
@@ -47,10 +47,10 @@ steps:
   - '-H'
   - 'Content-Type: application/x-application'
   - '--data-binary'
-  - '@multi-tenancy/incubator/hnc/bin/kubectl/kubectl-hns_linux_amd64'
+  - '@hierarchical-namespaces/bin/kubectl/kubectl-hns_linux_amd64'
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
-  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_linux_amd64'
+  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/hierarchical-namespaces/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_linux_amd64'
 # Upload plugin (Darwin)
 - name: gcr.io/cloud-builders/curl
   args:
@@ -59,10 +59,10 @@ steps:
   - '-H'
   - 'Content-Type: application/x-application'
   - '--data-binary'
-  - '@multi-tenancy/incubator/hnc/bin/kubectl/kubectl-hns_darwin_amd64'
+  - '@hierarchical-namespaces/bin/kubectl/kubectl-hns_darwin_amd64'
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
-  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_darwin_amd64'
+  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/hierarchical-namespaces/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_darwin_amd64'
 # Upload plugin (Krew tar file)
 - name: gcr.io/cloud-builders/curl
   args:
@@ -71,10 +71,10 @@ steps:
   - '-H'
   - 'Content-Type: application/x-application'
   - '--data-binary'
-  - '@multi-tenancy/incubator/hnc/bin/kubectl-hns.tar.gz'
+  - '@hierarchical-namespaces/bin/kubectl-hns.tar.gz'
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
-  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns.tar.gz'
+  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/hierarchical-namespaces/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns.tar.gz'
 # Upload plugin (Krew manifest file - to add to the Krew index)
 - name: gcr.io/cloud-builders/curl
   args:
@@ -83,12 +83,12 @@ steps:
   - '-H'
   - 'Content-Type: application/x-application'
   - '--data-binary'
-  - '@multi-tenancy/incubator/hnc/manifests/krew-kubectl-hns.yaml'
+  - '@hierarchical-namespaces/manifests/krew-kubectl-hns.yaml'
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
-  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/multi-tenancy/releases/$_HNC_RELEASE_ID/assets?name=krew-kubectl-hns.yaml'
+  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/hierarchical-namespaces/releases/$_HNC_RELEASE_ID/assets?name=krew-kubectl-hns.yaml'
 # Build Docker image
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_HNC_IMG_NAME:$_HNC_IMG_TAG', 'multi-tenancy/incubator/hnc']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/$_HNC_IMG_NAME:$_HNC_IMG_TAG', 'hierarchical-namespaces']
 
 images: ['gcr.io/$PROJECT_ID/$_HNC_IMG_NAME:$_HNC_IMG_TAG']

--- a/cmd/kubectl/main.go
+++ b/cmd/kubectl/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 package main
 
 import (
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/kubectl"
+	"sigs.k8s.io/hierarchical-namespaces/internal/kubectl"
 )
 
 func main() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -38,12 +38,12 @@ import (
 
 	// +kubebuilder:scaffold:imports
 
-	v1a2 "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/stats"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/validators"
+	v1a2 "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/reconcilers"
+	"sigs.k8s.io/hierarchical-namespaces/internal/stats"
+	"sigs.k8s.io/hierarchical-namespaces/internal/validators"
 )
 
 var (

--- a/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -39,7 +39,7 @@ spec:
             description: HNCConfigurationSpec defines the desired state of HNC configuration.
             properties:
               resources:
-                description: Resources defines the cluster-wide settings for resource synchronization. Note that 'roles' and 'rolebindings' are pre-configured by HNC with 'Propagate' mode and are omitted in the spec. Any configuration of 'roles' or 'rolebindings' are not allowed. To learn more, see https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/how-to.md#admin-types
+                description: Resources defines the cluster-wide settings for resource synchronization. Note that 'roles' and 'rolebindings' are pre-configured by HNC with 'Propagate' mode and are omitted in the spec. Any configuration of 'roles' or 'rolebindings' are not allowed. To learn more, see https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#admin-types
                 items:
                   description: ResourceSpec defines the desired synchronization state of a specific resource.
                   properties:
@@ -65,7 +65,7 @@ spec:
             description: HNCConfigurationStatus defines the observed state of HNC configuration.
             properties:
               conditions:
-                description: Conditions describes the errors, if any. If there are any conditions with "ActivitiesHalted" reason, this means that HNC cannot function in the affected namespaces. The HierarchyConfiguration object in each of the affected namespaces will have more information. To learn more about conditions, see https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/concepts.md#admin-conditions.
+                description: Conditions describes the errors, if any. If there are any conditions with "ActivitiesHalted" reason, this means that HNC cannot function in the affected namespaces. The HierarchyConfiguration object in each of the affected namespaces will have more information. To learn more about conditions, see https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/concepts.md#admin-conditions.
                 items:
                   description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                   properties:

--- a/docs/links.md
+++ b/docs/links.md
@@ -7,6 +7,6 @@ This file contains links to all the HNC documents (sorted by last updated).
 - [2019/12] [HNC CLI naming](http://bit.ly/hnc-cli-naming)
 - [2020/01] [HNC self-service namespaces UX](http://bit.ly/hnc-self-serve-ux)
 - [2020/01] [HNC type configuration](http://bit.ly/hnc-type-configuration)
-- [2020/02] [Metrics user guide: Stackdriver on GKE](https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/doc/metrics/stackdriver-gke.md)
+- [2020/02] [Metrics user guide: Stackdriver on GKE](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/doc/metrics/stackdriver-gke.md)
 - [2020/07] [HNC v1alpha2 API Proposal](http://bit.ly/hnc_v1alpha2)
 - [2020/11] [HNC Quickstart](https://bit.ly/hnc-quickstart)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -72,7 +72,7 @@ this for you.
 Set the following environment variables:
 
 ```bash
-export MT_ENDPOINT=https://api.github.com/repos/kubernetes-sigs/multi-tenancy
+export MT_ENDPOINT=https://api.github.com/repos/kubernetes-sigs/hierarchical-namespaces
 export HNC_USER=<your github name>
 export HNC_PAT=<your personal access token>
 export HNC_IMG_TAG=<the semantic version, eg v0.1.0-rc1>
@@ -197,7 +197,7 @@ vars:
 
 * `HNC_RELEASE_REPO_OWNER`: this is the Github repo owner - default is
   `kubernetes-sigs`, replace with your name (e.g. `adrianludwin`). The
-  `multi-tenancy` repo name is hardcoded and can't be changed.
+  `hierarchical-namespaces` repo name is hardcoded and can't be changed.
 * `HNC_RELEASE_REGISTRY`: default is `gcr.io/k8s-staging-multitenancy`, replace
   with your own registry (eg `gcr.io/adrians-project`).
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -25,7 +25,7 @@ see below.
 
 ## Older user guides
 
-* [HNC v0.6](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.6/incubator/hnc/docs/user-guide)
-* [HNC v0.5](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.5/incubator/hnc/docs/user-guide)
-* [HNC v0.4](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.4/incubator/hnc/docs/user-guide)
+* [HNC v0.6](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.6/docs/user-guide)
+* [HNC v0.5](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.5/docs/user-guide)
+* [HNC v0.4](https://github.com/kubernetes-sigs/multi-tenancy/tree/hnc-v0.4/docs/user-guide)
 * [HNC v0.3](https://docs.google.com/document/d/1XVVv1ha4j1WUaszu3mmlACeWPUJXbJhA6zntxswrsco)

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -7,7 +7,7 @@ Please feel free to suggest additional questions.
 
 You can contact us on:
 
-* [Github issues](https://github.com/kubernetes-sigs/multi-tenancy/issues)
+* [Github issues](https://github.com/kubernetes-sigs/hierarchical-namespaces/issues)
 * [Google Groups mailing list](https://groups.google.com/forum/#!forum/kubernetes-wg-multitenancy)
 * [#wg-multitenancy on Slack](https://kubernetes.slack.com/messages/wg-multitenancy)
 

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -494,7 +494,7 @@ relationships and configuration settings:
 kubectl get crds | grep .hnc.x-k8s.io | awk '{print $1}' | xargs kubectl delete crd
 
 # Delete the rest of HNC.
-kubectl delete -f https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-${HNC_VERSION}/hnc-manager.yaml
+kubectl delete -f https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/hnc-${HNC_VERSION}/hnc-manager.yaml
 ```
 
 <a name="admin-excluded-namespaces"/>
@@ -722,7 +722,7 @@ edit the `config` object directly, which will bypass this protection.
 
 HNC makes the following metrics available, and can be monitored via Stackdriver
 (next section) or Prometheus (experimental - see
-[#433](https://github.com/kubernetes-sigs/multi-tenancy/issues/433)).
+[#433](https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/433)).
 
 Our [best practices guide](best-practices.md#health) can help you use these
 metrics to ensure that HNC stays healthy.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/multi-tenancy/incubator/hnc
+module sigs.k8s.io/hierarchical-namespaces
 
 go 1.14
 

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -17,7 +17,7 @@ PROW_TMP := $(shell mktemp -d)
 # and that's probably good enough for us.
 #
 # Please keep this in sync with
-# https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-e2e.yaml.
+# https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/hierarchical-namespaces/hnc-e2e.yaml.
 # Also, when you do this, please also upgrade the version of Kind we download
 # in prow-run-e2e.sh in this directory.
 PROW_IMG ?= gcr.io/k8s-testimages/krte:v20210129-3799a64-master
@@ -33,10 +33,10 @@ prow-test:
 	@echo ~~~ Preparing to test prow-run-e2e.sh ~~~
 	@echo
 	@echo Cloning the repo
-	git clone https://github.com/kubernetes-sigs/multi-tenancy ${PROW_TMP}
+	git clone https://github.com/kubernetes-sigs/hierarchical-namespaces ${PROW_TMP}
 	@echo
 	@echo Copying run-e2e-tests in this directory to the synced directory
-	cp -p ./prow-run-e2e.sh ${PROW_TMP}/incubator/hnc/hack
+	cp -p ./prow-run-e2e.sh ${PROW_TMP}/hack
 	@echo
 	@echo ~~~ Testing prow-run-e2e.sh in KRTE ~~~
 	@echo
@@ -48,7 +48,7 @@ prow-test:
 		--network="host" \
 		-it \
 		${PROW_IMG} \
-		/local-test-start-dir/incubator/hnc/hack/prow-run-e2e.sh
+		/local-test-start-dir/hack/prow-run-e2e.sh
 
 # After calling 'make prow-test', the Kind cluster might still be present on the
 # *host* even though the Docker container has exited. Run this to find and

--- a/hack/krew-kubectl-hns.yaml
+++ b/hack/krew-kubectl-hns.yaml
@@ -21,9 +21,9 @@ spec:
   version: HNC_IMG_TAG
   caveats: |
     This plugin requires the most recent minor version of HNC on your cluster. Get it at:
-      https://github.com/kubernetes-sigs/multi-tenancy/releases/tag/hnc-HNC_IMG_TAG
+      https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/tag/hnc-HNC_IMG_TAG
     or via:
-      kubectl apply -f https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-HNC_IMG_TAG/hnc-manager.yaml
+      kubectl apply -f https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/hnc-HNC_IMG_TAG/hnc-manager.yaml
 
     This version of the plugin should work with HNC v0.6 and later - but for
     best results, use the version that matches the version of HNC on your
@@ -36,9 +36,9 @@ spec:
     * Only RBAC Roles and RoleBindings are propagated by default, but you can configure more.
 
     The user guide contains much more information.
-  homepage: https://github.com/HNC_RELEASE_REPO_OWNER/multi-tenancy/tree/master/incubator/hnc/docs/user-guide
+  homepage: https://github.com/HNC_RELEASE_REPO_OWNER/hierarchical-namespaces/tree/master/docs/user-guide
   platforms:
-  - uri: https://github.com/HNC_RELEASE_REPO_OWNER/multi-tenancy/releases/download/hnc-HNC_IMG_TAG/kubectl-hns.tar.gz
+  - uri: https://github.com/HNC_RELEASE_REPO_OWNER/hierarchical-namespaces/releases/download/hnc-HNC_IMG_TAG/kubectl-hns.tar.gz
     selector:
       matchLabels:
         os: linux
@@ -50,7 +50,7 @@ spec:
       - from: "bin/kubectl/LICENSE"
         to: "."
     bin: "./kubectl-hns_linux_amd64"
-  - uri: https://github.com/HNC_RELEASE_REPO_OWNER/multi-tenancy/releases/download/hnc-HNC_IMG_TAG/kubectl-hns.tar.gz
+  - uri: https://github.com/HNC_RELEASE_REPO_OWNER/hierarchical-namespaces/releases/download/hnc-HNC_IMG_TAG/kubectl-hns.tar.gz
     selector:
       matchLabels:
         os: darwin

--- a/internal/forest/forest.go
+++ b/internal/forest/forest.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 // Forest defines a forest of namespaces - that is, a set of trees. It includes methods to mutate

--- a/internal/forest/namespace.go
+++ b/internal/forest/namespace.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 // While storing the V in GVK is not strictly necessary to match what's in the HNC type configuration,

--- a/internal/forest/namespaceconditions.go
+++ b/internal/forest/namespaceconditions.go
@@ -1,7 +1,7 @@
 package forest
 
 import (
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 // HasLocalCritCondition returns if the namespace itself has any local critical conditions, ignoring

--- a/internal/foresttest/foresttest.go
+++ b/internal/foresttest/foresttest.go
@@ -1,8 +1,8 @@
 package foresttest
 
 import (
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 )
 
 // Create creates a forest with len(desc) namespaces, consecutively named a, b, etc. Each entry in

--- a/internal/kubectl/configdelete.go
+++ b/internal/kubectl/configdelete.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 var configDeleteCmd = &cobra.Command{

--- a/internal/kubectl/configdescribe.go
+++ b/internal/kubectl/configdescribe.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 var configDescribeCmd = &cobra.Command{

--- a/internal/kubectl/configset.go
+++ b/internal/kubectl/configset.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 var setResourceCmd = &cobra.Command{
@@ -53,7 +53,7 @@ var setResourceCmd = &cobra.Command{
 					fmt.Println("If you are sure you want to proceed with this operation, use the '--force' flag.")
 					fmt.Println("If you are not sure and would like to see what source objects would be overwritten," +
 						"please switch to 'Remove' first. To see how to enable propagation safely, refer to " +
-						"https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/how-to.md#admin-types")
+						"https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#admin-types")
 					os.Exit(1)
 				}
 				r.Mode = mode

--- a/internal/kubectl/describe.go
+++ b/internal/kubectl/describe.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 var describeCmd = &cobra.Command{

--- a/internal/kubectl/root.go
+++ b/internal/kubectl/root.go
@@ -32,8 +32,8 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/version"
 )
 
 var k8sClient *kubernetes.Clientset

--- a/internal/kubectl/set.go
+++ b/internal/kubectl/set.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 //hcUpdates struct stores name of namespaces against type of flag passed

--- a/internal/kubectl/tree.go
+++ b/internal/kubectl/tree.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 var (

--- a/internal/kubectl/version.go
+++ b/internal/kubectl/version.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/version"
+	"sigs.k8s.io/hierarchical-namespaces/internal/version"
 )
 
 var versionCmd = &cobra.Command{

--- a/internal/object/object.go
+++ b/internal/object/object.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 // metaPrefix returns the prefix (if any) of a label key.

--- a/internal/object/object_test.go
+++ b/internal/object/object_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 func TestCanonical(t *testing.T) {

--- a/internal/pkg/selectors/selectors.go
+++ b/internal/pkg/selectors/selectors.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 func ShouldPropagate(inst *unstructured.Unstructured, nsLabels labels.Set) (bool, error) {

--- a/internal/reconcilers/anchor.go
+++ b/internal/reconcilers/anchor.go
@@ -31,10 +31,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/metadata"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
 )
 
 // AnchorReconciler reconciles SubnamespaceAnchor CRs to make sure all the subnamespaces are

--- a/internal/reconcilers/anchor_test.go
+++ b/internal/reconcilers/anchor_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 )
 
 var _ = Describe("Anchor", func() {

--- a/internal/reconcilers/hierarchy_config.go
+++ b/internal/reconcilers/hierarchy_config.go
@@ -36,11 +36,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/metadata"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/stats"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
+	"sigs.k8s.io/hierarchical-namespaces/internal/stats"
 )
 
 // reconcileID is used purely to set the "rid" field in the log, so we can tell which log messages
@@ -195,7 +195,7 @@ func (r *HierarchyConfigReconciler) removeExcludedNamespaceLabel(log logr.Logger
 // descendants have been deleted, we would lose the knowledge that cascading deletion is enabled.
 func (r *HierarchyConfigReconciler) updateFinalizers(ctx context.Context, log logr.Logger, inst *api.HierarchyConfiguration, nsInst *corev1.Namespace, anms []string) {
 	// No-one should put a finalizer on a hierarchy config except us. See
-	// https://github.com/kubernetes-sigs/multi-tenancy/issues/623 as we try to enforce that.
+	// https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/623 as we try to enforce that.
 	switch {
 	case len(anms) == 0:
 		// There are no subnamespaces in this namespace. The HC instance can be safely deleted anytime.

--- a/internal/reconcilers/hierarchy_config_test.go
+++ b/internal/reconcilers/hierarchy_config_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 )
 
 var _ = Describe("Hierarchy", func() {

--- a/internal/reconcilers/hnc_config.go
+++ b/internal/reconcilers/hnc_config.go
@@ -24,9 +24,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/stats"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/stats"
 )
 
 // hnccrSingleton stores a pointer to the cluster-wide config reconciler so anyone can
@@ -360,7 +360,7 @@ func (r *ConfigReconciler) createObjectReconciler(gvk schema.GroupVersionKind, m
 		propagatedObjects: namespacedNameSet{},
 	}
 
-	// TODO: figure out MaxConcurrentReconciles option - https://github.com/kubernetes-sigs/multi-tenancy/issues/291
+	// TODO: figure out MaxConcurrentReconciles option - https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/291
 	if err := or.SetupWithManager(r.Manager, 10); err != nil {
 		r.Log.Error(err, "Error while trying to create ObjectReconciler", "gvk", gvk)
 		msg := fmt.Sprintf("Cannot sync objects of type %s: %s", gvk, err)

--- a/internal/reconcilers/hnc_config_test.go
+++ b/internal/reconcilers/hnc_config_test.go
@@ -12,7 +12,7 @@ import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 const (
@@ -30,7 +30,7 @@ const (
 	// experiments on workstations, tests are flaky when setting the countUpdateTime to 3 seconds and
 	// tests can always pass when setting the time to 4 seconds. We may need to increase the time in
 	// future if the config reconciler takes longer to update the status.  This issue is logged at
-	// https://github.com/kubernetes-sigs/multi-tenancy/issues/871
+	// https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/871
 	//
 	// Update: since Prow machines appear to be overloaded, and since we've seen some random failures
 	// in counting tests, I'm increasing this to 6s - aludwin, Oct 2020

--- a/internal/reconcilers/object.go
+++ b/internal/reconcilers/object.go
@@ -38,13 +38,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/metadata"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/object"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/pkg/selectors"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/stats"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
+	"sigs.k8s.io/hierarchical-namespaces/internal/object"
+	"sigs.k8s.io/hierarchical-namespaces/internal/pkg/selectors"
+	"sigs.k8s.io/hierarchical-namespaces/internal/stats"
 )
 
 // syncAction is the action to take after Reconcile syncs with the in-memory forest.
@@ -581,7 +581,7 @@ func (r *ObjectReconciler) writeObject(ctx context.Context, log logr.Logger, ins
 		log.Info("Updating propagated object")
 		err = r.Update(ctx, inst)
 		// RoleBindings can't have their Roles changed after they're created
-		// (see  https://github.com/kubernetes-sigs/multi-tenancy/issues/798).
+		// (see  https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/798).
 		// If an RB was quickly delete and re-created in an ancestor namespace
 		// - fast enough that by the time that HNC notices, the new RB exists; or
 		// if there's a change to the RBs when HNC isn't running - HNC could see
@@ -761,7 +761,7 @@ func (r *ObjectReconciler) SetupWithManager(mgr ctrl.Manager, maxReconciles int)
 
 		// Unlike the other HNC reconcilers, the object reconciler can easily be affected by objects
 		// that do not directly cause reconciliations when they're modified - see, e.g.,
-		// https://github.com/kubernetes-sigs/multi-tenancy/issues/1154. To address this, replace the
+		// https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/1154. To address this, replace the
 		// default exponential backoff with one with a 10s cap.
 		//
 		// I wanted to pick five seconds since I feel like that's about how much time it would take you to check

--- a/internal/reconcilers/object_test.go
+++ b/internal/reconcilers/object_test.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 )
 
 var _ = Describe("Exceptions", func() {

--- a/internal/reconcilers/setup.go
+++ b/internal/reconcilers/setup.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 )
 
 // FakeDeleteCRDClient is a "fake" client used for testing only

--- a/internal/reconcilers/suite_test.go
+++ b/internal/reconcilers/suite_test.go
@@ -36,9 +36,9 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/reconcilers"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/internal/reconcilers/test_helpers_test.go
+++ b/internal/reconcilers/test_helpers_test.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 // GVKs maps a resource to its corresponding GVK.

--- a/internal/validators/anchor.go
+++ b/internal/validators/anchor.go
@@ -9,9 +9,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 )
 
 // AnchorServingPath is where the validator will run. Must be kept in sync with the
@@ -52,7 +52,7 @@ func (v *Anchor) Handle(ctx context.Context, req admission.Request) admission.Re
 		return deny(metav1.StatusReasonBadRequest, err.Error())
 	}
 	if decoded == nil {
-		// https://github.com/kubernetes-sigs/multi-tenancy/issues/688
+		// https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/688
 		return allow("")
 	}
 
@@ -124,7 +124,7 @@ func (v *Anchor) decodeRequest(log logr.Logger, in admission.Request) (*anchorRe
 	if in.Operation == k8sadm.Delete {
 		log.V(1).Info("Decoding a delete request.")
 		if in.OldObject.Raw == nil {
-			// https://github.com/kubernetes-sigs/multi-tenancy/issues/688
+			// https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/688
 			return nil, nil
 		}
 		err = v.decoder.DecodeRaw(in.OldObject, anchor)

--- a/internal/validators/anchor_test.go
+++ b/internal/validators/anchor_test.go
@@ -6,9 +6,9 @@ import (
 	. "github.com/onsi/gomega"
 	k8sadm "k8s.io/api/admission/v1"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/foresttest"
 )
 
 func TestCreateSubnamespaces(t *testing.T) {

--- a/internal/validators/hierarchy.go
+++ b/internal/validators/hierarchy.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 )
 
 const (
@@ -114,7 +114,7 @@ func (v *Hierarchy) handle(ctx context.Context, log logr.Logger, req *request) a
 	// Early exit: the HNC SA can do whatever it wants. This is because if an illegal HC already
 	// exists on the K8s server, we need to be able to update its status even though the rest of the
 	// object wouldn't pass legality. We should probably only give the HNC SA the ability to modify
-	// the _status_, though. TODO: https://github.com/kubernetes-sigs/multi-tenancy/issues/80.
+	// the _status_, though. TODO: https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/80.
 	if isHNCServiceAccount(req.ui) {
 		return allow("HNC SA")
 	}

--- a/internal/validators/hierarchy_test.go
+++ b/internal/validators/hierarchy_test.go
@@ -10,10 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/foresttest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/reconcilers"
 )
 
 func TestStructure(t *testing.T) {

--- a/internal/validators/hncconfig.go
+++ b/internal/validators/hncconfig.go
@@ -12,11 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/pkg/selectors"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/pkg/selectors"
+	"sigs.k8s.io/hierarchical-namespaces/internal/reconcilers"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 // ConfigServingPath is where the validator will run. Must be kept in sync with the

--- a/internal/validators/hncconfig_test.go
+++ b/internal/validators/hncconfig_test.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/foresttest"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
 var (

--- a/internal/validators/namespace.go
+++ b/internal/validators/namespace.go
@@ -9,10 +9,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 )
 
 // NamespaceServingPath is where the validator will run. Must be kept in sync with the
@@ -53,7 +53,7 @@ func (v *Namespace) Handle(ctx context.Context, req admission.Request) admission
 		return deny(metav1.StatusReasonBadRequest, err.Error())
 	}
 	if decoded == nil {
-		// https://github.com/kubernetes-sigs/multi-tenancy/issues/688
+		// https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/688
 		return allow("")
 	}
 
@@ -116,7 +116,7 @@ func (v *Namespace) illegalExcludedNamespaceLabel(req *nsRequest) admission.Resp
 			// excluded namespace would pass but the label is immediately removed; when
 			// the VWHConfiguration is there but the reconcilers are down, any request
 			// gets denied anyway.
-			msg := fmt.Sprintf("You cannot exclude this namespace using the %q label. See https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/docs/user-guide/concepts.md#excluded-namespace-label for detail.", api.LabelExcludedNamespace)
+			msg := fmt.Sprintf("You cannot exclude this namespace using the %q label. See https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/concepts.md#excluded-namespace-label for detail.", api.LabelExcludedNamespace)
 			return deny(metav1.StatusReasonForbidden, msg)
 		}
 	}
@@ -151,7 +151,7 @@ func (v *Namespace) cannotDeleteSubnamespace(req *nsRequest) admission.Response 
 	}
 
 	// If the anchor doesn't exist, we want to allow it to be deleted anyway.
-	// See issue https://github.com/kubernetes-sigs/multi-tenancy/issues/847.
+	// See issue https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/847.
 	anchorExists := v.Forest.Get(parent).HasAnchor(req.ns.Name)
 	if anchorExists {
 		msg := fmt.Sprintf("The namespace %s is a subnamespace. Please delete the anchor from the parent namespace %s to delete the subnamespace.", req.ns.Name, parent)
@@ -183,7 +183,7 @@ func (v *Namespace) decodeRequest(log logr.Logger, in admission.Request) (*nsReq
 	// which will be empty for a DELETE request.
 	if in.Operation == k8sadm.Delete {
 		if in.OldObject.Raw == nil {
-			// See https://github.com/kubernetes-sigs/multi-tenancy/issues/688. OldObject can be nil in
+			// See https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/688. OldObject can be nil in
 			// K8s 1.14 and earlier.
 			return nil, nil
 		}

--- a/internal/validators/namespace_test.go
+++ b/internal/validators/namespace_test.go
@@ -6,10 +6,10 @@ import (
 	. "github.com/onsi/gomega"
 	k8sadm "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/foresttest"
 )
 
 func TestDeleteSubNamespace(t *testing.T) {

--- a/internal/validators/object.go
+++ b/internal/validators/object.go
@@ -17,12 +17,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/config"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/metadata"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/object"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/pkg/selectors"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
+	"sigs.k8s.io/hierarchical-namespaces/internal/object"
+	"sigs.k8s.io/hierarchical-namespaces/internal/pkg/selectors"
 )
 
 // ObjectsServingPath is where the validator will run. Must be kept in sync with the

--- a/internal/validators/object_test.go
+++ b/internal/validators/object_test.go
@@ -16,12 +16,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/foresttest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/foresttest"
 
-	api "sigs.k8s.io/multi-tenancy/incubator/hnc/api/v1alpha2"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/metadata"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/reconcilers"
+	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/metadata"
+	"sigs.k8s.io/hierarchical-namespaces/internal/reconcilers"
 )
 
 // TestEarlyExit tests requests that, without an early exit, would *definitely* be denied because

--- a/internal/validators/setup.go
+++ b/internal/validators/setup.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	cert "github.com/open-policy-agent/cert-controller/pkg/rotator"
-	"sigs.k8s.io/multi-tenancy/incubator/hnc/internal/forest"
+	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 )
 
 const (

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -320,7 +320,7 @@ func TearDownHNC(hncVersion string) {
 	TryRunQuietly("k delete crd hncconfigurations.hnc.x-k8s.io")
 	TryRunQuietly("kubectl delete -f ../../manifests/hnc-manager.yaml")
 	if hncVersion != "" {
-		TryRunQuietly("kubectl delete -f https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-" + hncVersion + "/hnc-manager.yaml")
+		TryRunQuietly("kubectl delete -f https://github.com/kubernetes-sigs/hierarchical-namespaces/releases/download/hnc-" + hncVersion + "/hnc-manager.yaml")
 	}
 	// Wait for HNC to be fully torn down (the namespace and the CRDs are gone).
 	runShouldNotContain(1, "hnc-system", 10, "kubectl get ns")

--- a/test/e2e/delete_crd_test.go
+++ b/test/e2e/delete_crd_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
 var _ = Describe("When deleting CRDs", func() {

--- a/test/e2e/issues_test.go
+++ b/test/e2e/issues_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
 var _ = Describe("Issues", func() {
@@ -215,7 +215,7 @@ var _ = Describe("Issues", func() {
 		MustRun("kubectl delete subns", nsChild, "-n", nsParent)
 	})
 
-	// Disabled due to https://github.com/kubernetes-sigs/multi-tenancy/issues/1492 - now that HNC
+	// Disabled due to https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/1492 - now that HNC
 	// *can* propagate cluster-admin rolebindings (see the test for #772), we need to find some new
 	// way to test what HNC does when it *can't* propagate something.
 	XIt("Should have CannotPropagateObject and CannotUpdateObject events - replacing obsolete issues #328, #605, #771", func() {

--- a/test/e2e/kubectl_test.go
+++ b/test/e2e/kubectl_test.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
 var _ = Describe("HNS set-config", func() {

--- a/test/e2e/namespace_test.go
+++ b/test/e2e/namespace_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
 var _ = Describe("Namespace", func() {

--- a/test/e2e/quickstart_test.go
+++ b/test/e2e/quickstart_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
 var _ = Describe("Quickstart", func() {

--- a/test/e2e/rolebinding_test.go
+++ b/test/e2e/rolebinding_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
-	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
 var _ = Describe("HNC should delete and create a new Rolebinding instead of updating it", func() {

--- a/test/e2e/subnamespace_test.go
+++ b/test/e2e/subnamespace_test.go
@@ -2,7 +2,7 @@ package e2e
 
 import (
 	. "github.com/onsi/ginkgo"
-	. "sigs.k8s.io/multi-tenancy/incubator/hnc/pkg/testutils"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
 )
 
 var _ = Describe("Subnamespaces", func() {


### PR DESCRIPTION
This PR should come after https://github.com/kubernetes-sigs/hierarchical-namespaces/pull/2

I manually changed all links and directories to remove multi-tenancy, incubator/hnc, etc into the root directory in this repo. The only links I kept original were links to existing releases.

After running this I did:
```
make build
make kubectl
make kind-reboot
make test-smoke
make test-e2e
```
Here are e2e results running against kind:

```
Ran 22 of 34 Specs in 564.680 seconds
SUCCESS! -- 22 Passed | 0 Failed | 1 Pending | 11 Skipped
--- PASS: TestE2e (564.68s)
PASS
ok  	sigs.k8s.io/hierarchical-namespaces/test/e2e	564.804s
```