### PR TITLE
Fix e2e tests

### DIFF
--- a/hack/prow-run-e2e.sh
+++ b/hack/prow-run-e2e.sh
@@ -21,7 +21,6 @@
 # in this file too! Look down a few lines to see/update the Kind version.
 
 set -euf -o pipefail
-cd incubator/hnc
 
 start_time="$(date -u +%s)"
 echo


### PR DESCRIPTION
The e2e tests refer to the old "incubator/hnc" directory which doesn't
exist in this repo.

Tested: as usual, I don't have any way to test Prow configs or flows.
However, this is in response to a Prow failure that clearly identifies
this line.