### PR TITLE
Migrate items listed in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,26 @@
-/tmp
-/log
-/out
-/bin
-.local
+# Release files
+releases/
 
-# IDEA project files
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+manifests
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
 .idea/
 *.iml
 **/*.iml
@@ -14,3 +30,6 @@
 *.ipr
 *.iws
 *.yaml-e
+*.swp
+*.swo
+*~


### PR DESCRIPTION
For example, exclude changes in the "manifests" folder, etc.

See the `.gitignore` in the old repo - https://github.com/kubernetes-sigs/multi-tenancy/blob/master/incubator/hnc/.gitignore