### PR TITLE
Replace excluded namespace label with included

### DIFF
--- a/api/v1alpha2/hierarchy_types.go
+++ b/api/v1alpha2/hierarchy_types.go
@@ -44,9 +44,9 @@ const (
 	// about this standard label when we invented our own).
 	LabelManagedByApps = "app.kubernetes.io/managed-by"
 
-	// LabelExcludedNamespace is the label added by users on the namespaces that
-	// should be excluded from our validators, e.g. "kube-system".
-	LabelExcludedNamespace = MetaGroup + "/excluded-namespace"
+	// LabelIncludedNamespace is the label added by HNC on the namespaces that
+	// should be enforced by our validators.
+	LabelIncludedNamespace = MetaGroup + "/included-namespace"
 )
 
 const (

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,12 +3,6 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    # Add excluded namespace label on `hnc-system` namespace by default because
-    # without this label when installing HNC, there will be a deadlock that
-    # the object webhook fails close so the cert-rotator cannot create/update
-    # `hnc-webhook-server-cert` secret object for VWHConfiguration, thus the
-    # webhooks will never be ready.
-    hnc.x-k8s.io/excluded-namespace: "true"
   name: system
 ---
 apiVersion: apps/v1

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -7,19 +7,19 @@ webhooks:
 - name: objects.hnc.x-k8s.io
   timeoutSeconds: 2
   sideEffects: None
-  # We only filter out excluded namespaces from this object validator so that
-  # when HNC (webhook service specifically) is down, operations in the excluded
+  # We only apply this object validator on non-excluded namespaces, which have
+  # the "included-namespace" label set by the HC reconciler, so that when HNC
+  # (webhook service specifically) is down, operations in the excluded
   # namespaces won't be affected. Validators on HNC CRs are not filtered because
   # they are supposed to prevent abuse of HNC CRs in excluded namespaces.
-  # Namespace validator is not filtered to prevent abuse of excluded namespace.
-  # Unfortunately, this means that when HNC is down, we will block updates on all
-  # namespaces, even "excluded" ones, but anyone who can update namespaces like
-  # `kube-system` should likely be able to delete the VWHConfiguration to make
-  # the updates.
+  # Namespace validator is not filtered to prevent abuse of the included-namespace
+  # label on excluded namespaces. Unfortunately, this means that when HNC is
+  # down, we will block updates on all namespaces, even "excluded" ones, but
+  # anyone who can update namespaces like `kube-system` should likely be able to
+  # delete the VWHConfiguration to make the updates.
   namespaceSelector:
-    matchExpressions:
-    - key: hnc.x-k8s.io/excluded-namespace
-      operator: DoesNotExist
+    matchLabels:
+      hnc.x-k8s.io/included-namespace: "true"
   rules:
   # This overwrites the rules specified in the object validator to patch object
   # scope of `namespaced` since there's no kubebuilder marker for `scope`.


### PR DESCRIPTION
Part of #9
Next PR would be updating the label concept doc.

Missing `excluded-namespace` label on system namespaces would break the
entire cluster. Instead of always trying hard to make sure the
`excluded-namespace` label are set, this PR replaces it with included
namespace concept (`included-namespace` label added by HC reconciler on
all namespaces except those listed as excluded in the HNC container
args).

Remove the `excluded-namespace` label. Add the `included-namespace` label.
Update HC reonciler to always set the `included-namespace` label to true
on non-excluded namespaces and remove it on excluded namespaces. Update
namespace webhook to block adding/updating the new label improperly.

Update the Makefile to remove the `excluded-namespace` label setting.

Tested by `make test` and `make test-e2e`.