### PR TITLE
Update docs to add included-namespace label and deprecate excluded label

### DIFF
--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -531,7 +531,7 @@ We are considering replacing this with the standard
 
 #### hnc.x-k8s.io/excluded-namespace (label on namespaces)
 
-***Excluded namespaces configuration is only available in HNC v0.8 and later***
+***This label is only used in HNC v0.8 (not applicable in HNC v0.9 and later)***
 
 This label should be added to namespaces such as `kube-system` and `kube-public`
 so that HNC's validating webhook cannot accidentally prevent operations in these
@@ -606,3 +606,15 @@ namespace and turn it back into a subnamespace.
 This is the [tree label](#basic-labels) which is documented above. It is set by
 HNC on namespaces and (unless `managed-by` was set first) cannot be modified by
 anyone other than HNC.
+
+<a name="included-namespace-label">
+
+#### hnc.x-k8s.io/included-namespace (label on namespaces)
+
+***This label is only available in HNC v0.9 and later***
+
+HNC's mutating webhook sets this label on non-excluded namespaces and removes
+this label from excluded namespaces by default. This protects your cluster's
+critical namespaces from problems with HNC, because some webhooks only operate
+in namespaces with this label. See [Excluding namespaces from HNC](how-to.md#admin-excluded-namespaces)
+for more information.

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -417,10 +417,14 @@ release notes for that version.
 
 #### Prerequisites
 
-***These prerequisites apply to HNC v0.8, and are not needed in HNC v0.9.***
+***These prerequisites apply to HNC v0.8 and later.***
 
-Prior to installing HNC, add the `hnc.x-k8s.io/excluded-namespaces` label to
-your critical system namespaces:
+Ensure `kube-system`, `kube-public` and `kube-node-lease` namespaces are listed
+in the [argument list](#admin-cli-args) with the option `--excluded-namespace`.
+
+**In HNC v0.8 (not applicable in HNC v0.9 and later)**, prior to installing HNC,
+add the `hnc.x-k8s.io/excluded-namespaces` label to your critical system
+namespaces:
 
 ```
 kubectl label ns kube-system hnc.x-k8s.io/excluded-namespace=true
@@ -522,31 +526,25 @@ an excluded namespace, or create a subnamespace within it, will be rejected by
 HNC. However, the critical webhooks will not operate in the excluded namespace,
 protecting your cluster's stability.
 
-In order to exclude namespaces from HNC _before_ installing it:
-
-1. Add the `hnc.x-k8s.io/excluded-namespace` label with the value of `true` to
-   all critical namespaces. At a minimum, this label should be applied to
+In order to exclude namespaces from HNC:
+1. Determine the namespaces you want to exclude. At a minimum, you should exclude
    `kube-system`, `kube-public`, and `kube-node-lease` as described in the
-   [installation instructions](#admin-install), but you may add additional
-   namespaces if you wish.
-2. Ensure that all the namespaces you have excluded are also listed in the
-   [argument list](#admin-cli-args) with the option `--excluded-namespace`. By
-   default, the HNC manifests include all the critical system namespaces listed
-   above, but you can exclude any namespace you like.
-3. Apply the HNC manifest.
+   [installation instructions](#admin-install). By default, the HNC manifests
+   exclude all these critical system namespaces listed above, but you can exclude
+   any namespace you like.
+1. **This is required in HNC v0.8 only, but not applicable in HNC v0.9 and later** - Add the
+ `hnc.x-k8s.io/excluded-namespace` label with the value of `true` to all the
+  excluded namespaces. 
+1. Ensure that all the namespaces you want to exclude are listed in the
+   [argument list](#admin-cli-args) with the option `--excluded-namespace`.
+1. Apply the HNC manifest.
 
-To exclude an additional namespace from HNC _after_ it has been installed,
-follow these steps:
-
-1. Add the namespace to the list of `--excluded-namespace` [command line
-   args](#admin-cli-args).
-2. Apply the `hnc.x-k8s.io/excluded-namespace=true` label to the namespace.
-
-If you attempt to apply the `hnc.x-k8s.io/excluded-namespace` label to any
-namespace that is not _also_ listed in the command line args, HNC will not allow
-the change, or will remove the label when it is started. This prevents users
-with edit access to a single namespace from removing themselves from HNC without
-permission of the HNC administrator.
+**In HNC v0.8 only (not applicable in HNC v0.9 and later)** - If you attempt to
+apply the `hnc.x-k8s.io/excluded-namespace` label to any namespace that is
+not _also_ listed in the command line args, HNC will not allow the change, or
+will remove the label when it is started. This prevents users with edit access
+to a single namespace from removing themselves from HNC without permission of
+the HNC administrator.
 
 
 <a name="admin-backup-restore"/>


### PR DESCRIPTION
Part of #9.

Add `included-namespace` label to the HNC concepts page and mark
`excluded-namespace` label as deprecated in HNC v0.9 and later.

Update how-to page with new instructions on installing HNC and excluding
namespaces in HNC.

See previews:
* [excluded-namespace label](https://github.com/yiqigao217/hierarchical-namespaces/blob/3e2a8e3e5c757041c6ccc302e9af0d23a7807342/docs/user-guide/concepts.md#hncx-k8sioexcluded-namespace-label-on-namespaces)
* [included-namespace label](https://github.com/yiqigao217/hierarchical-namespaces/blob/3e2a8e3e5c757041c6ccc302e9af0d23a7807342/docs/user-guide/concepts.md#hncx-k8sioincluded-namespace-label-on-namespaces)
* [installing HNC](https://github.com/yiqigao217/hierarchical-namespaces/blob/3e2a8e3e5c757041c6ccc302e9af0d23a7807342/docs/user-guide/how-to.md#prerequisites)
* [excluding NS from HNC](https://github.com/yiqigao217/hierarchical-namespaces/blob/3e2a8e3e5c757041c6ccc302e9af0d23a7807342/docs/user-guide/how-to.md#excluding-namespaces-from-hnc)
