### PR TITLE
Add e2e tests for included-namespace label

### DIFF
--- a/test/e2e/issues_test.go
+++ b/test/e2e/issues_test.go
@@ -341,8 +341,8 @@ var _ = Describe("Issues that require repairing HNC", func() {
 		nsParent = "parent"
 		nsChild  = "child"
 		nsNonExcluded = "regular"
-		// Use `hnc-system` for this test because HNC adds excluded namespace label
-		// to `hnc-system` namespace by default.
+		// Use `hnc-system` for this test because HNC excludes `hnc-system`
+		//namespace by default.
 		nsExcluded = "hnc-system"
 	)
 

--- a/test/e2e/wrong_included_namespace.yaml
+++ b/test/e2e/wrong_included_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    hnc.x-k8s.io/included-namespace: "wrong"
+    hnc.x-k8s.io/testNamespace: "true"
+  name: e2e-test-namespace-a


### PR DESCRIPTION
Part of #9.

Verify newly-created non-excluded namespaces are mutated with
`included-namespace` label. Verify rejecting illegal updates of the
label.

Tested by `make test-e2e`, all 33 passed, 1 pending, 1 skipped.