### PR TITLE
Remove sideEffects:None webhook patches

### DIFF
--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -6,7 +6,6 @@ metadata:
 webhooks:
 - name: objects.hnc.x-k8s.io
   timeoutSeconds: 2
-  sideEffects: None
   # We only apply this object validator on non-excluded namespaces, which have
   # the "included-namespace" label set by the HC reconciler, so that when HNC
   # (webhook service specifically) is down, operations in the excluded
@@ -36,11 +35,3 @@ webhooks:
     resources:
     - '*'
     scope: "Namespaced"
-- name: subnamespaceanchors.hnc.x-k8s.io
-  sideEffects: None
-- name: hierarchyconfigurations.hnc.x-k8s.io
-  sideEffects: None
-- name: hncconfigurations.hnc.x-k8s.io
-  sideEffects: None
-- name: namespaces.hnc.x-k8s.io
-  sideEffects: None


### PR DESCRIPTION
Fixes #38.

Remove the `sideEffects` wehbook patches because it's available in the
v1 kubebuilder marker.

Tested: there's no change in the generated manifests. All the
`sideEffects: None` are still there.