### PR TITLE
Disable kube-rbac-proxy by default

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -29,13 +29,16 @@ patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
-- manager_auth_proxy_patch.yaml
+  # DISABLING Auth Proxy by default since HNC does not expose
+  # any PII information via it's metrics.
+  # If this changes in the future, this should be enaled by default. 
+# - manager_auth_proxy_patch.yaml
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, uncomment the following line and
   # comment manager_auth_proxy_patch.yaml.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
-#- manager_prometheus_metrics_patch.yaml
+- manager_prometheus_metrics_patch.yaml
 
 - manager_webhook_patch.yaml
 #  # Uncomment below if ../certmanager is enabled.


### PR DESCRIPTION
HNC does not expose PII information via `/metrics` endpoint. Disabling employing kube-rbac-proxy by default.

Tested: make test-smoke passes.