### PR TITLE
Add presubmit to ensure make generate doesn't produce diffs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,9 @@ vet:
 generate: controller-gen
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
 
+check-generate: generate
+	@test -z $(shell git status --untracked-files=no --porcelain)
+
 # Use the version of controller-gen that's checked into vendor/ (see
 # hack/tools.go to see how it got there).
 controller-gen:

--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -38,3 +38,6 @@ hack_dir=$(dirname ${BASH_SOURCE})
 echo "Running 'make check-fmt test'"
 cd "$hack_dir/.."
 make check-fmt test
+
+echo "Running 'make check-generate test'"
+make check-generate


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/25  

Keep the same logic as check-fmt 

Maybe we can add [verify-gofmt.sh](https://github.com/kubernetes/kubernetes/blob/master/hack/verify-generated-files.sh), [verify-generated-files.sh](https://github.com/kubernetes/kubernetes/blob/master/hack/verify-generated-files.sh) for these presubmit checks? 
