### PR TITLE
Rename workflow name

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,4 +1,4 @@
-name: release
+name: build
 
 on: 
   create:


### PR DESCRIPTION
Remove master branch because this would create an image for every commit rather than every release. 

Signed-off-by: Harsh Thakur <harshthakur9030@gmail.com>