### PR TITLE
Include Windows CLI to releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ build: generate fmt vet manifests
 	     -o bin/kubectl/kubectl-hns_linux_arm \
 	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
 	     ./cmd/kubectl/main.go
+	GOOS=windows GOARCH=amd64 go build \
+	     -o bin/kubectl/kubectl-hns_windows_amd64.exe \
+	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
+	    ./cmd/kubectl/main.go
 
 # Clean all binaries (manager and kubectl)
 clean: krew-uninstall

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -63,6 +63,18 @@ steps:
   - '-u'
   - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
   - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/hierarchical-namespaces/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_darwin_amd64'
+# Upload plugin (Windows)
+- name: gcr.io/cloud-builders/curl
+  args:
+  - '-X'
+  - 'POST'
+  - '-H'
+  - 'Content-Type: application/x-application'
+  - '--data-binary'
+  - '@hierarchical-namespaces/bin/kubectl/kubectl-hns_windows_amd64.exe'
+  - '-u'
+  - '$_HNC_USER:$_HNC_PERSONAL_ACCESS_TOKEN'
+  - 'https://uploads.github.com/repos/$_HNC_REPO_OWNER/hierarchical-namespaces/releases/$_HNC_RELEASE_ID/assets?name=kubectl-hns_windows_amd64.exe'
 # Upload plugin (Krew tar file)
 - name: gcr.io/cloud-builders/curl
   args:

--- a/hack/krew-kubectl-hns.yaml
+++ b/hack/krew-kubectl-hns.yaml
@@ -58,3 +58,15 @@ spec:
       - from: "bin/kubectl/LICENSE"
         to: "."
     bin: "./kubectl-hns_darwin_amd64"
+  - uri: https://github.com/HNC_RELEASE_REPO_OWNER/hierarchical-namespaces/releases/download/hnc-HNC_IMG_TAG/kubectl-hns.tar.gz
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    sha256: HNC_KREW_TAR_SHA256
+    files:
+      - from: "bin/kubectl/kubectl-hns_windows_amd64.exe"
+        to: "."
+      - from: "bin/kubectl/LICENSE"
+        to: "."
+    bin: "./kubectl-hns_windows_amd64.exe"


### PR DESCRIPTION
Looks that there have been some discussion about this on kubernetes-sigs/multi-tenancy#1260 and #22 but now PR earlier so here it is.

Storing it with name `kubectl-hns.exe` to any folder on `PATH` environment variable makes `kubectl hns` command working.