### PR TITLE
Add Excluded Resource Names to HNC config

### DIFF
--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -348,6 +348,19 @@ overwritten by your actions. You can then rewrite the exception to safely
 exclude those objects, or else delete the conflicting objects to allow them to
 be replaced.
 
+#### Built-in exceptions
+
+There are some built-in exceptions to prevent certain known (auto-generated)
+objects from being propagated by HNC.
+
+If ConfigMaps propagation is enabled, any ConfigMaps named `istio-ca-root-cert`
+or `kube-root-ca.crt` will not be propagated. These are auto-created in new
+namespaces by Istio and Kubernetes respectively. As they are auto-generated,
+adding annotations is not possible and HNC will by default exclude them.
+
+Similarly, Kubernetes ServiceAccount Secrets will also by default be excluded
+from propagation.
+
 <a name="admin"/>
 
 ## Administration

--- a/internal/reconcilers/object_test.go
+++ b/internal/reconcilers/object_test.go
@@ -390,6 +390,19 @@ var _ = Describe("Basic propagation", func() {
 		Expect(objectInheritedFrom(ctx, "configmaps", barName, "foo-config")).Should(Equal(fooName))
 	})
 
+	It("should not propagate builtin exclusions", func() {
+		setParent(ctx, barName, fooName)
+		makeObject(ctx, "configmaps", fooName, "istio-ca-root-cert")
+		makeObject(ctx, "configmaps", fooName, "kube-root-ca.crt")
+		makeObject(ctx, "configmaps", fooName, "gets-propagated")
+		addToHNCConfig(ctx, "", "configmaps", api.Propagate)
+
+		// We expect normal configmaps to be propagated, but builtin exclusions not to be.
+		Eventually(hasObject(ctx, "configmaps", barName, "gets-propagated")).Should(BeTrue())
+		Eventually(hasObject(ctx, "configmaps", barName, "istio-ca-root-cert")).Should(BeFalse())
+		Eventually(hasObject(ctx, "configmaps", barName, "kube-root-ca.crt")).Should(BeFalse())
+	})
+
 	It("should be removed if the hierarchy changes", func() {
 		setParent(ctx, barName, fooName)
 		setParent(ctx, bazName, barName)


### PR DESCRIPTION
PR add built-in exception/exclusion list, of configmap names that are excluded from propagation

It was proposed that add a listed of excluded resource names to hnc-config as below:
But this may be something that is added later when there are other clearer usecases
```
apiVersion: hnc.x-k8s.io/v1alpha2
kind: HNCConfiguration
metadata:
  name: config
spec:
  resources:
  - mode: Propagate
    resource: secrets
  - mode: Propagate
    resource: configmaps
    excludedNames: ["istio-ca-root-cert", "kube-root-ca.crt"]  
```
Any resource matching the listed names will fail shouldPropogate and not be propagated by hnc

this give solution to istio / kubernetes configmap resources which are auto generated in every namespace and cannot be propagated due to conflicts, it may help for other similarly created resources which need to be excluded

note: helps to resolve https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/66
 but by explicit exclusions of resource names (rather than using labels) so as to address `kube-root-ca.crt` as well `istio-ca-root-cert` configmaps