### PR TITLE
Enabled HNC leader election

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,3 +42,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update


### PR DESCRIPTION
- block reconciler controller setup until instance becomes the leader using `mgr.Elected()` channel
- adds leases permissions to cluster role
- tunes leader election default configurations