### PR TITLE
Improve usability of unmanaged namespaces

### DIFF
--- a/internal/anchor/validator.go
+++ b/internal/anchor/validator.go
@@ -79,14 +79,14 @@ func (v *Validator) handle(req *anchorRequest) admission.Response {
 
 	switch req.op {
 	case k8sadm.Create:
-		// Can't create subnamespaces in excluded namespaces
-		if !config.IsNamespaceIncluded(pnm) {
-			msg := fmt.Sprintf("Cannot create a subnamespace in the excluded namespace %q", pnm)
+		// Can't create subnamespaces in unmanaged namespaces
+		if why := config.WhyUnmanaged(pnm); why != "" {
+			msg := fmt.Sprintf("Cannot create a subnamespace in the unmanaged namespace %q (%s)", pnm, why)
 			return webhooks.Deny(metav1.StatusReasonForbidden, msg)
 		}
-		// Can't create subnamespaces using excluded namespace names
-		if !config.IsNamespaceIncluded(cnm) {
-			msg := fmt.Sprintf("Cannot create a subnamespace using the excluded namespace name %q", cnm)
+		// Can't create subnamespaces using unmanaged namespace names
+		if why := config.WhyUnmanaged(cnm); why != "" {
+			msg := fmt.Sprintf("Cannot create a subnamespace using the unmanaged namespace name %q (%s)", cnm, why)
 			return webhooks.Deny(metav1.StatusReasonForbidden, msg)
 		}
 

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -1,7 +1,5 @@
 package config
 
-import "regexp"
-
 // UnpropgatedAnnotations is a list of annotations on objects that should _not_ be propagated by HNC.
 // Much like HNC itself, other systems (such as GKE Config Sync) use annotations to "claim" an
 // object - such as deleting objects it doesn't recognize. By removing these annotations on
@@ -10,11 +8,3 @@ import "regexp"
 // This value is controlled by the --unpropagated-annotation command line, which may be set multiple
 // times.
 var UnpropagatedAnnotations []string
-
-// ExcludedNamespaces is a list of namespaces used by reconcilers and validators
-// to exclude namespaces that shouldn't be reconciled or validated.
-//
-// This value is controlled by the --excluded-namespace command line, which may
-// be set multiple times.
-var excludedNamespaces map[string]bool
-var includedNamespacesRegex *regexp.Regexp

--- a/internal/config/namespace.go
+++ b/internal/config/namespace.go
@@ -4,12 +4,29 @@ import (
 	"regexp"
 )
 
+var (
+	// excludedNamespaces is a list of namespaces used by reconcilers and validators
+	// to exclude namespaces that shouldn't be reconciled or validated.
+	//
+	// This value is controlled by the --excluded-namespace command line, which may
+	// be set multiple times.
+	excludedNamespaces map[string]bool
+
+	// includedNamespacesRegex is the compiled regex of included namespaces
+	includedNamespacesRegex *regexp.Regexp
+
+	// includedNamespacesStr is the original pattern of the regex. It must
+	// only be used to generate error messages.
+	includedNamespacesStr string
+)
+
 func SetNamespaces(regex string, excluded ...string) {
 	if regex == "" {
 		regex = ".*"
 	}
 
-	includedNamespacesRegex = regexp.MustCompile("^" + regex + "$")
+	includedNamespacesStr = "^" + regex + "$"
+	includedNamespacesRegex = regexp.MustCompile(includedNamespacesStr)
 
 	excludedNamespaces = make(map[string]bool)
 	for _, exn := range excluded {
@@ -17,14 +34,32 @@ func SetNamespaces(regex string, excluded ...string) {
 	}
 }
 
-func IsNamespaceIncluded(name string) bool {
-	if excludedNamespaces[name] {
-		return false
+// WhyUnamanged returns a human-readable message explaining why the given
+// namespace is unmanaged, or an empty string if it *is* managed.
+func WhyUnmanaged(nm string) string {
+	// We occasionally check if the _parent_ of a namespace is managed.
+	// It's an error for a managed namespace to have an unmanaged parent,
+	// so we'll treat "no parent" as managed.
+	if nm == "" {
+		return ""
+	}
+
+	if excludedNamespaces[nm] {
+		return "excluded by the HNC administrator"
 	}
 
 	if includedNamespacesRegex == nil { // unit tests
-		return true
+		return ""
 	}
 
-	return includedNamespacesRegex.MatchString(name)
+	if !includedNamespacesRegex.MatchString(nm) {
+		return "does not match the regex set by the HNC administrator: `" + includedNamespacesStr + "`"
+	}
+
+	return ""
+}
+
+// IsManagedNamespace is the same as WhyUnmanaged but converts the response to a bool for convenience.
+func IsManagedNamespace(nm string) bool {
+	return WhyUnmanaged(nm) == ""
 }

--- a/internal/config/namespace_test.go
+++ b/internal/config/namespace_test.go
@@ -8,16 +8,16 @@ import (
 func TestIsNamespaceIncluded(t *testing.T) {
 
 	tests := []struct {
-		name              string
-		regex             string
-		excludeNamespaces []string
-		expect            bool
+		name     string
+		regex    string
+		excluded []string
+		expect   bool
 	}{
-		{name: "foobar", regex: "foo.*", excludeNamespaces: []string{"bar"}, expect: true},
-		{name: "bar", regex: "foo-.*", excludeNamespaces: []string{"bar"}, expect: false},
-		{name: "bar", regex: ".*", excludeNamespaces: []string{"bar"}, expect: false},
-		{name: "foo", regex: ".*", excludeNamespaces: []string{"bar"}, expect: true},
-		{name: "foo", regex: ".*", excludeNamespaces: []string{"bar", "foo"}, expect: false},
+		{name: "foobar", regex: "foo.*", excluded: []string{"bar"}, expect: true},
+		{name: "bar", regex: "foo-.*", excluded: []string{"bar"}, expect: false},
+		{name: "bar", regex: ".*", excluded: []string{"bar"}, expect: false},
+		{name: "foo", regex: ".*", excluded: []string{"bar"}, expect: true},
+		{name: "foo", regex: ".*", excluded: []string{"bar", "foo"}, expect: false},
 	}
 
 	for _, tc := range tests {
@@ -25,11 +25,11 @@ func TestIsNamespaceIncluded(t *testing.T) {
 			g := NewWithT(t)
 
 			// Test
-			SetNamespaces(tc.regex, tc.excludeNamespaces...)
-			isIncluded := IsNamespaceIncluded(tc.name)
+			SetNamespaces(tc.regex, tc.excluded...)
+			got := IsManagedNamespace(tc.name)
 
 			// Report
-			g.Expect(isIncluded).Should(Equal(tc.expect))
+			g.Expect(got).Should(Equal(tc.expect))
 		})
 	}
 

--- a/internal/hierarchyconfig/reconciler_test.go
+++ b/internal/hierarchyconfig/reconciler_test.go
@@ -41,17 +41,6 @@ var _ = Describe("Hierarchy", func() {
 		Eventually(HasChild(ctx, barName, fooName)).Should(Equal(true))
 	})
 
-	It("should remove the hierarchyconfiguration singleton in an excluded namespacee", func() {
-		// Set the excluded-namespace "kube-system"'s parent to "bar".
-		config.SetNamespaces("", "kube-system")
-		exHier := NewHierarchy("kube-system")
-		exHier.Spec.Parent = barName
-		UpdateHierarchy(ctx, exHier)
-
-		// Verify the hierarchyconfiguration singleton is deleted.
-		Eventually(CanGetHierarchy(ctx, "kube-system")).Should(Equal(false))
-	})
-
 	It("should set IllegalParent condition if the parent is an excluded namespace", func() {
 		// Set bar's parent to the excluded-namespace "kube-system".
 		config.SetNamespaces("", "kube-system")

--- a/internal/hierarchyconfig/validator_test.go
+++ b/internal/hierarchyconfig/validator_test.go
@@ -39,9 +39,9 @@ func TestStructure(t *testing.T) {
 		// should see denial message of excluded namespace for `kube-system`. As for
 		// `kube-public`, we will see missing parent/child instead of excluded
 		// namespaces denial message for it.
-		{name: "exclude parent kube-system", nnm: "a", pnm: "kube-system", fail: true, msgContains: "Cannot set the parent to the excluded namespace"},
+		{name: "exclude parent kube-system", nnm: "a", pnm: "kube-system", fail: true, msgContains: "excluded"},
 		{name: "missing parent kube-public", nnm: "a", pnm: "kube-public", fail: true, msgContains: "does not exist"},
-		{name: "exclude child kube-system", nnm: "kube-system", pnm: "a", fail: true, msgContains: "Cannot set the excluded namespace"},
+		{name: "exclude child kube-system", nnm: "kube-system", pnm: "a", fail: true, msgContains: "excluded"},
 		{name: "missing child kube-public", nnm: "kube-public", pnm: "a", fail: true, msgContains: "HNC has not reconciled namespace"},
 	}
 	for _, tc := range tests {

--- a/internal/namespace/mutator.go
+++ b/internal/namespace/mutator.go
@@ -52,7 +52,7 @@ func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.R
 // Currently, we only add `included-namespace` label to non-excluded namespaces
 // if the label is missing.
 func (m *Mutator) handle(log logr.Logger, ns *corev1.Namespace) {
-	if !config.IsNamespaceIncluded(ns.Name) {
+	if !config.IsManagedNamespace(ns.Name) {
 		return
 	}
 
@@ -61,7 +61,7 @@ func (m *Mutator) handle(log logr.Logger, ns *corev1.Namespace) {
 		if ns.Labels == nil {
 			ns.Labels = map[string]string{}
 		}
-		log.Info("Not an excluded namespace; set included-namespace label.")
+		log.Info("Managed namespace is missing included-namespace label; adding")
 		ns.Labels[api.LabelIncludedNamespace] = "true"
 	}
 }

--- a/internal/namespace/validator.go
+++ b/internal/namespace/validator.go
@@ -120,11 +120,12 @@ func (v *Validator) illegalIncludedNamespaceLabel(req *nsRequest) admission.Resp
 			return webhooks.Allow("")
 		}
 	}
-	isIncluded := config.IsNamespaceIncluded(req.ns.Name)
+
+	isIncluded := config.IsManagedNamespace(req.ns.Name)
 
 	// An excluded namespaces should not have included-namespace label.
 	if !isIncluded && hasLabel {
-		msg := fmt.Sprintf("You cannot enforce webhook rules on this excluded namespace using the %q label. "+
+		msg := fmt.Sprintf("You cannot enforce webhook rules on this unmanaged namespace using the %q label. "+
 			"See https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/concepts.md#included-namespace-label "+
 			"for detail.", api.LabelIncludedNamespace)
 		return webhooks.Deny(metav1.StatusReasonForbidden, msg)
@@ -135,7 +136,7 @@ func (v *Validator) illegalIncludedNamespaceLabel(req *nsRequest) admission.Resp
 	// Note: since we have a mutating webhook to set the correct label if it's
 	// missing before this, we only need to check if the label value is correct.
 	if isIncluded && labelValue != "true" {
-		msg := fmt.Sprintf("You cannot change the value of the %q label. It has to be set as true on a non-excluded namespace. "+
+		msg := fmt.Sprintf("You cannot change the value of the %q label. It has to be set as true on all managed namespaces. "+
 			"See https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/concepts.md#included-namespace-label "+
 			"for detail.", api.LabelIncludedNamespace)
 		return webhooks.Deny(metav1.StatusReasonForbidden, msg)

--- a/internal/objects/reconciler.go
+++ b/internal/objects/reconciler.go
@@ -200,7 +200,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	resp := ctrl.Result{}
 	log := logutils.WithRID(r.Log).WithValues("trigger", req.NamespacedName)
 
-	if !config.IsNamespaceIncluded(req.Namespace) {
+	if !config.IsManagedNamespace(req.Namespace) {
 		return resp, nil
 	}
 

--- a/internal/objects/validator.go
+++ b/internal/objects/validator.go
@@ -59,8 +59,8 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 	// Note: This is added just in case the "hnc.x-k8s.io/excluded-namespace=true"
 	// label is not added on the excluded namespaces. VWHConfiguration of this VWH
 	// already has a `namespaceSelector` to exclude namespaces with the label.
-	if !config.IsNamespaceIncluded(req.Namespace) {
-		return webhooks.Allow("excluded namespace " + req.Namespace)
+	if !config.IsManagedNamespace(req.Namespace) {
+		return webhooks.Allow("unmanaged namespace " + req.Namespace)
 	}
 	// Allow changes to the types that are not in propagate mode. This is to dynamically enable/disable
 	// object webhooks based on the types configured in hncconfig. Since the current admission rules only


### PR DESCRIPTION
This change makes it a nondestructive operation to switch a namespace
from managed to unmanaged and back, by _not_ deleting the HC or anchors
while a namespace is unmanaged. It also fixes one serious bug
(namespaces could not be changed to roots because the unnamed namespace
didn't match the regex) and adds a lot more details in the error
messages. Finally, it allows users to fix broken hierarchies by removing
a formerly-managed parent.

I also changed the terminology from "excluded" to "unmanaged"
throughout.

Testing: This is hard to test automatically since it requires constant
redeployments of HNC. So I did extensive manual testing instead:

* Try to arrange hierarchies with unmanaged namespace, both excluded
(e.g hnc-system) and ones that don't match the regex. Verify that the
error messages clearly indicate the correct problem.
* Create a legal hierarchy and then break it by changing the regex.
Verify that I can fix it without restarting HNC.
* Create a legal hierarchy, break it with the regex, and then restore it
with the regex. Verify that the original hierarchy comes back.
* Verify that anchors and hierarchyconfigs lose their finalizers when
their namespaces become unmanaged, and get them back if they become
managed again.