### PR TITLE
Enable HNC leader election in controllers

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -216,6 +216,12 @@ func createManager() ctrl.Manager {
 	// TODO: Better understand the behaviour of Burst, and consider making it equal to QPS if
 	// it turns out to be harmful.
 	cfg.Burst = int(cfg.QPS * 1.5)
+
+	// If leader election is disabled then treat this instance as the HNC leader
+	if !enableLeaderElection {
+		config.IsLeader = true
+	}
+
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,3 +41,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update

--- a/internal/config/controller.go
+++ b/internal/config/controller.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type NonLeaderController struct {
+	controller.Controller
+}
+
+func (nlc *NonLeaderController) NeedLeaderElection() bool {
+	return false
+}
+
+func AddNonLeaderCtrl(mgr manager.Manager, c controller.Controller) error {
+	return mgr.Add(&NonLeaderController{c})
+}

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -8,3 +8,6 @@ package config
 // This value is controlled by the --unpropagated-annotation command line, which may be set multiple
 // times.
 var UnpropagatedAnnotations []string
+
+// IsLeader is global which repesents whether this HNC instance is the leader
+var IsLeader bool

--- a/internal/forest/forest.go
+++ b/internal/forest/forest.go
@@ -37,8 +37,9 @@ type namedNamespaces map[string]*Namespace
 // TypeSyncer syncs objects of a specific type. Reconcilers implement the interface so that they can be
 // called by the HierarchyReconciler if the hierarchy changes.
 type TypeSyncer interface {
-	// SyncNamespace syncs objects of a namespace for a specific type.
-	SyncNamespace(context.Context, logr.Logger, string) error
+	// SyncObjects syncs objects of a namespace for a specific type
+	// string is namespace, or "" for all namespaces
+	SyncObjects(context.Context, logr.Logger, string) error
 
 	// Provides the GVK that is handled by the reconciler who implements the interface.
 	GetGVK() schema.GroupVersionKind

--- a/internal/setup/reconcilers.go
+++ b/internal/setup/reconcilers.go
@@ -19,6 +19,8 @@ import (
 // This function is called both from main.go as well as from the integ tests.
 func CreateReconcilers(mgr ctrl.Manager, f *forest.Forest, maxReconciles int, useFakeClient bool) error {
 	crd.Setup(mgr, useFakeClient)
+	setupLog := ctrl.Log.WithName("setup").WithName("reconcilers")
+	setupLog.Info("Creating reconcilers")
 
 	hcChan := make(chan event.GenericEvent)
 	anchorChan := make(chan event.GenericEvent)
@@ -63,7 +65,9 @@ func CreateReconcilers(mgr ctrl.Manager, f *forest.Forest, maxReconciles int, us
 	// If LeaderElection is enabled then Watch for Elected() to enable controller writes
 	if !config.IsLeader {
 		go func() {
+			setupLog.Info("Waiting to be elected leader...")
 			<-mgr.Elected()
+			setupLog.Info("Elected as leader")
 			config.IsLeader = true
 			ar.BecomeLeader()
 			hnccfgr.BecomeLeader()


### PR DESCRIPTION
- updates hnc reconcilers to be leader aware and only perform writes when leader
- non leader instance run updating it's forest tree cache, but will not perform any writes
- all hnc instances can respond to validating / mutating webhooks
- when a leader election occurs objects are re-queued
- adds leases permissions to cluster role

---
manual testing completed with 3 instances and --enable-leader-election
- manually killing leader instance at different times and running tests creating many parent child ns hierarchys
- validated that the new instance took over and handled updating child ns resources 
- also validated that all 3 instances were successfully handling validation webhook calls 