### PR TITLE
Work around kubectl bug in 1.22 (trunk)

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -235,6 +235,8 @@ func RunCommand(cmdln ...string) (string, error) {
 	prefix := fmt.Sprintf("[%d] Running: ", time.Now().Unix())
 	GinkgoT().Log(prefix, args)
 	cmd := exec.Command(args[0], args[1:]...)
+	// Work around https://github.com/kubernetes/kubectl/issues/1098#issuecomment-929743957:
+	cmd.Env = append(os.Environ(), "KUBECTL_COMMAND_HEADERS=false")
 	stdout, err := cmd.CombinedOutput()
 	return string(stdout), err
 }


### PR DESCRIPTION
By default, Kubectl does not exit properly after long-running commands
like `kubectl run` starting in 1.22
(https://github.com/kubernetes/kubectl/issues/1098). This change
disables the new feature to work around the problem, as suggested in the
issue itself.

Tested: hierarchical network policy test hangs without this change,
passes with it.