### PR TITLE
fix: metrics port for the controller-manager #115

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -13,6 +13,6 @@ spec:
   ports:
   - name: https
     port: 8443
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

This PR fixes the port in the `hnc-controller-manager-metrics-service` service from `targetPort: https` to `targetPort: metrics` as there is no `https` named port in the controller manager container, but its named as `metrics`.

Fixes: #115 