### PR TITLE
Simplify condition handling

### DIFF
--- a/internal/forest/namespaceconditions.go
+++ b/internal/forest/namespaceconditions.go
@@ -1,36 +1,47 @@
 package forest
 
 import (
+	"fmt"
+
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
 )
 
-// HasLocalCritCondition returns if the namespace itself has any local critical conditions, ignoring
-// its ancestors. Any code with the "Crit" prefix is a critical condition.
-func (ns *Namespace) HasLocalCritCondition() bool {
+// IsHalted returns true if this namespace has an ActivitiesHalted condition for any reason *other*
+// than one of its ancestors also being halted.
+func (ns *Namespace) IsHalted() bool {
+	if ns == nil {
+		return false
+	}
 	for _, cond := range ns.conditions {
-		if cond.Type == api.ConditionActivitiesHalted && cond.Reason != api.ReasonAncestor {
+		if cond.Type == api.ConditionActivitiesHalted {
 			return true
 		}
 	}
 	return false
 }
 
-// GetCritAncestor returns the name of the first ancestor with a critical condition, or the empty
-// string if there are no such ancestors. It *can* return the name of the current namespace.
-func (ns *Namespace) GetCritAncestor() string {
-	if ns.HasLocalCritCondition() {
-		return ns.name
-	}
-	if ns.Parent() == nil {
+// GetHaltedRoot returns the name of the lowest subtree that's halted for any reason *other* than a
+// higher ancestor being halted. This can be the name of the current namespace, or the empty string
+// if there are no halted ancestors.
+func (ns *Namespace) GetHaltedRoot() string {
+	if ns == nil {
 		return ""
 	}
-	return ns.Parent().GetCritAncestor()
+	if ns.IsHalted() {
+		return ns.name
+	}
+	return ns.Parent().GetHaltedRoot()
 }
 
 // SetCondition adds a new condition to the current condition list.
+//
+// Any condition with ReasonAncestor is ignored; this is added dynamically when calling
+// Conditions().
 func (ns *Namespace) SetCondition(tp, reason, msg string) {
-	oldCond := ns.conditions
-	ns.conditions = append(oldCond, api.NewCondition(tp, reason, msg))
+	if reason == api.ReasonAncestor {
+		return
+	}
+	ns.conditions = append(ns.conditions, api.NewCondition(tp, reason, msg))
 }
 
 // ClearConditions set conditions to nil.
@@ -40,5 +51,11 @@ func (ns *Namespace) ClearConditions() {
 
 // Conditions returns a full list of the conditions in the namespace.
 func (ns *Namespace) Conditions() []api.Condition {
+	if root := ns.GetHaltedRoot(); root != "" && root != ns.name {
+		msg := fmt.Sprintf("Propagation paused in %q and its descendants due to ActivitiesHalted condition on ancestor %q", ns.name, root)
+		ret := []api.Condition{api.NewCondition(api.ConditionActivitiesHalted, api.ReasonAncestor, msg)}
+		return append(ret, ns.conditions...)
+	}
+
 	return ns.conditions
 }

--- a/internal/hierarchyconfig/validator.go
+++ b/internal/hierarchyconfig/validator.go
@@ -175,11 +175,11 @@ func (v *Validator) checkNS(ns *forest.Namespace) admission.Response {
 		return deny(metav1.StatusReasonServiceUnavailable, msg)
 	}
 
-	// Deny the request if the namespace has a critical ancestor - but not if it's critical itself,
-	// since we may be trying to resolve the critical condition.
-	critAnc := ns.GetCritAncestor()
-	if critAnc != "" && critAnc != ns.Name() {
-		msg := fmt.Sprintf("The ancestor %q of namespace %q has a critical condition, which must be resolved before any changes can be made to the hierarchy configuration.", critAnc, ns.Name())
+	// Deny the request if the namespace has a halted root - but not if it's halted itself, since we
+	// may be trying to resolve the halted condition.
+	haltedRoot := ns.GetHaltedRoot()
+	if haltedRoot != "" && haltedRoot != ns.Name() {
+		msg := fmt.Sprintf("The ancestor %q of namespace %q has a critical condition, which must be resolved before any changes can be made to the hierarchy configuration.", haltedRoot, ns.Name())
 		return deny(metav1.StatusReasonForbidden, msg)
 	}
 


### PR DESCRIPTION
While implementing managed labels, I found two problems with our
condition handling:

1. They were using old terminology like "Critical Condition" instead of
the newer "ActivitiesHalted".
2. Instead of identifying problems like cycles right away, we delayed
their identification until the end of the syncing process. This means
that code that depends on knowing about cycles - like setting tree
labels - needed to be at the end of the sync process instead of in the
middle where they belonged (and couldn't set conditions themselves).

This change fixes both problems.

Tested: all existing unit/integ tests; no change in functionality.