### PR TITLE
Don't store external tree labels explicitly

### DIFF
--- a/internal/hierarchyconfig/validator_test.go
+++ b/internal/hierarchyconfig/validator_test.go
@@ -70,8 +70,8 @@ func TestChangeParentOnManagedBy(t *testing.T) {
 	l := zap.New()
 
 	// Make c and d external namespaces
-	f.Get("c").ExternalTreeLabels = map[string]int{"c" + api.LabelTreeDepthSuffix: 0}
-	f.Get("d").ExternalTreeLabels = map[string]int{"d" + api.LabelTreeDepthSuffix: 0}
+	f.Get("c").Manager = "external-tool"
+	f.Get("d").Manager = "external-tool"
 
 	// These cases test changing parent for internal or external namespaces, described
 	// in the table at https://bit.ly/hnc-external-hierarchy#heading=h.z9mkbslfq41g

--- a/internal/namespace/validator.go
+++ b/internal/namespace/validator.go
@@ -194,7 +194,12 @@ func (v *Validator) illegalIncludedNamespaceLabel(req *nsRequest) admission.Resp
 // namespace name cannot be updated.
 func (v *Validator) nameExistsInExternalHierarchy(req *nsRequest) admission.Response {
 	for _, nm := range v.Forest.GetNamespaceNames() {
-		if _, ok := v.Forest.Get(nm).ExternalTreeLabels[req.ns.Name]; ok {
+		ns := v.Forest.Get(nm)
+		if !ns.IsExternal() {
+			continue
+		}
+		externalTreeLabels := ns.GetTreeLabels()
+		if _, ok := externalTreeLabels[req.ns.Name]; ok {
 			msg := fmt.Sprintf("The namespace name %q is reserved by the external hierarchy manager %q.", req.ns.Name, v.Forest.Get(nm).Manager)
 			return webhooks.Deny(metav1.StatusReasonAlreadyExists, msg)
 		}

--- a/internal/namespace/validator_test.go
+++ b/internal/namespace/validator_test.go
@@ -124,10 +124,10 @@ func TestCreateNamespace(t *testing.T) {
 	f := foresttest.Create("-")
 	vns := &Validator{Forest: f}
 	a := f.Get("a")
-	a.ExternalTreeLabels = map[string]int{
-		nm:       1,
-		a.Name(): 0,
-	}
+	a.SetLabels(map[string]string{
+		nm + api.LabelTreeDepthSuffix:       "1",
+		a.Name() + api.LabelTreeDepthSuffix: "0",
+	})
 
 	// Requested namespace uses "exhier" as name.
 	ns := &corev1.Namespace{}


### PR DESCRIPTION
While preparing to add managed labels, I found it was weird to have an
explicit set of external tree labels when these can easily be derived
from the existing list of labels. This change removes the explicit
external tree labels and instead recomputes them on-demand, which should
be rare (external namespaces are neither used nor synced frequently).

Tested: existing unit/integ tests (no change in functionality)