### PR TITLE
Add cli argument `--disable-enforced-types`

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -68,6 +68,7 @@ var (
 	managedNamespaceLabels  arrayArg
 	managedNamespaceAnnots  arrayArg
 	includedNamespacesRegex string
+	disableEnforcedTypes    bool
 )
 
 func init() {
@@ -103,10 +104,14 @@ func main() {
 	flag.BoolVar(&restartOnSecretRefresh, "cert-restart-on-secret-refresh", false, "Kills the process when secrets are refreshed so that the pod can be restarted (secrets take up to 60s to be updated by running pods)")
 	flag.Var(&managedNamespaceLabels, "managed-namespace-label", "A regex indicating the labels on namespaces that are managed by HNC. These labels may only be set via the HierarchyConfiguration object. All regexes are implictly wrapped by \"^...$\". This argument can be specified multiple times. See the user guide for more information.")
 	flag.Var(&managedNamespaceAnnots, "managed-namespace-annotation", "A regex indicating the annotations on namespaces that are managed by HNC. These annotations may only be set via the HierarchyConfiguration object. All regexes are implictly wrapped by \"^...$\". This argument can be specified multiple times. See the user guide for more information.")
+	flag.BoolVar(&disableEnforcedTypes, "disable-enforced-types", false, "Disables the enforced types \"Roles\" and \"Rolebindings\" - thus making them removable.")
 	flag.Parse()
 
 	// Assign the array args to the configuration variables after the args are parsed.
 	config.UnpropagatedAnnotations = unpropagatedAnnotations
+	// Assign the "disable enforced types" toggle
+	config.EnforcedTypesDisabled = disableEnforcedTypes
+
 	config.SetNamespaces(includedNamespacesRegex, excludedNamespaces...)
 	if err := config.SetManagedMeta(managedNamespaceLabels, managedNamespaceAnnots); err != nil {
 		setupLog.Error(err, "Illegal flag values")

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -873,3 +873,8 @@ Interesting parameters include:
   load on your metrics database (through increased metric cardinality) and also
   by increasing how carefully you need to guard your metrics against
   unauthorized viewers.
+* `--disable-enforced-types`: not set by default. If set, the default enforced
+  types `roles` and `rolebindings` are not enforced anymore, meaning they are
+  not propagated by default and have to be configured additionally, if required.
+  This option allows the use of HNC for other object kinds, while not necessarily
+  managing roles and rolebindings.

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -8,3 +8,10 @@ package config
 // This value is controlled by the --unpropagated-annotation command line, which may be set multiple
 // times.
 var UnpropagatedAnnotations []string
+
+// EnforcedTypesDisabled is a boolean toggle that can be used to disable the default enforced types
+// "role" and "rolebindings" from being managed by HNC. If set to `true`, it's possible to remove
+// both kinds of objects from the default managed types.
+//
+// This option is controlled by the --disable-enforced-types command line argument.
+var EnforcedTypesDisabled bool

--- a/internal/hncconfig/validator.go
+++ b/internal/hncconfig/validator.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 	"sigs.k8s.io/hierarchical-namespaces/internal/selectors"
 
@@ -100,7 +101,7 @@ func (v *Validator) validateTypes(inst *api.HNCConfiguration, ts gvkSet) admissi
 		gr := schema.GroupResource{Group: r.Group, Resource: r.Resource}
 		field := field.NewPath("spec", "resources").Index(i)
 		// Validate the type configured is not an HNC enforced type.
-		if api.IsEnforcedType(r) {
+		if !config.EnforcedTypesDisabled && api.IsEnforcedType(r) {
 			return webhooks.DenyInvalid(field, fmt.Sprintf("Invalid configuration of %s in the spec, because it's enforced by HNC "+
 				"with 'Propagate' mode. Please remove it from the spec.", gr))
 		}

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -382,6 +382,26 @@ func RecoverHNC() {
 	cleanupNamespaces(a, b)
 }
 
+func AddDisableEnforcedTypesArg() {
+	// If hncRecoverPath is not set, we should not get here, but if we do, return early and - propably - fail the tests
+	// as the changes done in this prep function require the original manifest file to recover a "normal" state.
+	if hncRecoverPath == "" {
+		return
+	}
+
+	// read manifest file, look for the "command:" line and add the required arg as a new line before the match
+	content, err := ioutil.ReadFile(hncRecoverPath)
+	if err != nil {
+		return
+	}
+	manifest := string(content)
+	manifest = strings.Replace(manifest, "        command:", "        - --disable-enforced-types\n        command:", 1)
+	MustApplyYAML(manifest)
+
+	// give HNC time to redeploy the manager
+	time.Sleep(5 * time.Second)
+}
+
 func writeTempFile(cxt string) string {
 	f, err := ioutil.TempFile(os.TempDir(), "e2e-test-*.yaml")
 	Expect(err).Should(BeNil())

--- a/test/e2e/disabled_enforced_types_test.go
+++ b/test/e2e/disabled_enforced_types_test.go
@@ -1,0 +1,68 @@
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "sigs.k8s.io/hierarchical-namespaces/pkg/testutils"
+)
+
+var _ = Describe("With disabled enforced types", func() {
+
+	const (
+		nsParent = "parent"
+		nsChild  = "child"
+	)
+
+	BeforeEach(func() {
+		CheckHNCPath()
+		AddDisableEnforcedTypesArg()
+		CleanupTestNamespaces()
+	})
+
+	AfterEach(func() {
+		CleanupTestNamespaces()
+		RecoverHNC()
+	})
+
+	It("should have no synchronized resources configured by default", func() {
+		// check for roles and rolebindings not being present by default
+		RunShouldNotContainMultiple([]string{"roles", "rolebindings"}, defTimeout, "kubectl hns config describe")
+
+		// create roles propagation
+		MustRun("kubectl hns config set-resource roles --group rbac.authorization.k8s.io --mode Propagate")
+		RunShouldContain("roles", defTimeout, "kubectl hns config describe")
+
+		// create secrets propagation
+		MustRun("kubectl hns config set-resource secrets --mode Propagate")
+		RunShouldContain("secrets", defTimeout, "kubectl hns config describe")
+
+		// remove it again and recheck that it's gone
+		MustRun("kubectl hns config delete-type --group rbac.authorization.k8s.io --resource roles")
+		RunShouldNotContainMultiple([]string{"roles", "rolebindings"}, defTimeout, "kubectl hns config describe")
+	})
+
+	It("should synchronize roles if asked to", func() {
+		// create namespaces and set relation
+		CreateNamespace(nsParent)
+		CreateNamespace(nsChild)
+		MustRun("kubectl hns set", nsChild, "--parent", nsParent)
+
+		// create role and check that it's not propagated
+		MustRun("kubectl -n", nsParent, "create role", nsParent+"-sre", "--verb=update --resource=deployments")
+		RunShouldContain("No resources found in "+nsChild, defTimeout, "kubectl -n", nsChild, "get roles")
+
+		// check for roles and rolebindings not being present by default
+		RunShouldNotContainMultiple([]string{"roles", "rolebindings"}, defTimeout, "kubectl hns config describe")
+
+		// create roles propagation
+		MustRun("kubectl hns config set-resource roles --group rbac.authorization.k8s.io --mode Propagate")
+		RunShouldContain("roles", defTimeout, "kubectl hns config describe")
+
+		RunShouldContain("Parent: "+nsParent, defTimeout, "kubectl hns describe", nsChild)
+		RunShouldContain(nsChild, propogationTimeout, "kubectl hns describe", nsParent)
+		RunShouldContain(nsParent+"-sre", propogationTimeout, "kubectl -n", nsChild, "get roles")
+
+		// remove it again and recheck that it's gone
+		MustRun("kubectl hns config delete-type --group rbac.authorization.k8s.io --resource roles")
+		RunShouldNotContainMultiple([]string{"roles", "rolebindings"}, defTimeout, "kubectl hns config describe")
+	})
+})


### PR DESCRIPTION
This kinda implements the request made in #104, as it makes it possible to disable the default enforced types `roles` and `rolebindings` with an additional cli argument `--disable-enforced-types` that can be used with the hnc-manager. The old behaviour (using enforcedTypes) is the default.

Tested: added new e2e tests and checked them against a vanilla k8s cluster. No issues found.

---

I'll try to implement the per-object-level filtering proposed by @adrianludwin in https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/104#issuecomment-946865077 in another PR soon.

If there are any issues with this PR, please let me know. This being my first contribution to a k8s / cncf project, I've probably missed something ;)
