### PR TITLE
Validate anchor names are RFC 1123 labels

### DIFF
--- a/internal/anchor/validator_test.go
+++ b/internal/anchor/validator_test.go
@@ -31,6 +31,7 @@ func TestCreateSubnamespaces(t *testing.T) {
 		{name: "with an existing ns name (the ns is not a subnamespace of it)", pnm: "c", cnm: "b", fail: true},
 		{name: "for existing non-subns child", pnm: "a", cnm: "c", fail: true},
 		{name: "for existing subns", pnm: "a", cnm: "b"},
+		{name: "for non DNS label compliant child", pnm: "a", cnm: "child.01", fail: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes: #118

This PR will validate the name of the anchor to make sure the child namespace is in compliance with RFC 1123.


Tested: added unit test, and verified the following error message
if I ran this manually: Subnamespace child.01 is not a valid namespace
name: a lowercase RFC 1123 label must consist of lower case alphanumeric
characters or '-', and must start and end with an alphanumeric character
(e.g. 'my-name',  or '123-abc', regex used for validation is
'[a-z0-9]([-a-z0-9]*[a-z0-9])?')

/cc @adrianludwin