### PR TITLE
Add per-object-level filtering based on labels (excluding Rancher-generated resources)

### DIFF
--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -361,6 +361,14 @@ adding annotations is not possible and HNC will by default exclude them.
 Similarly, Kubernetes ServiceAccount Secrets will also by default be excluded
 from propagation.
 
+In addition, propagation exclusions are also used for Rancher-managed Kubernetes
+clusters. Rancher uses a "project" concept that bundles namespaces and thus sets
+roles, rolebindings, etc. for all namespaces of a project. This leads to
+conflicts with HNC, so all resources created by Rancher (which are automatically
+labeled with `"cattle.io/creator": "norman"` by Rancher, cf. [their
+docs](https://rancher.com/docs/rancher/v2.6/en/system-tools/#remove)) are
+excluded from propagation.
+
 <a name="admin"/>
 
 ## Administration

--- a/internal/integtest/helpers.go
+++ b/internal/integtest/helpers.go
@@ -300,9 +300,9 @@ func MakeObject(ctx context.Context, resource string, nsName, name string) {
 	createdObjects = append(createdObjects, inst)
 }
 
-// MakeObjectWithAnnotation creates an empty object with annotation given kind in a specific
+// MakeObjectWithAnnotations creates an empty object with annotation given kind in a specific
 // namespace. The kind and its corresponding GVK should be included in the GVKs map.
-func MakeObjectWithAnnotation(ctx context.Context, resource string, nsName,
+func MakeObjectWithAnnotations(ctx context.Context, resource string, nsName,
 	name string, a map[string]string) {
 	inst := &unstructured.Unstructured{}
 	inst.SetGroupVersionKind(GVKs[resource])
@@ -313,9 +313,22 @@ func MakeObjectWithAnnotation(ctx context.Context, resource string, nsName,
 	createdObjects = append(createdObjects, inst)
 }
 
-// UpdateObjectWithAnnotation gets an object given it's kind, nsName and name, adds the annotation
+// MakeObjectWithLabels creates an empty object with label given kind in a specific
+// namespace. The kind and its corresponding GVK should be included in the GVKs map.
+func MakeObjectWithLabels(ctx context.Context, resource string, nsName,
+	name string, l map[string]string) {
+	inst := &unstructured.Unstructured{}
+	inst.SetGroupVersionKind(GVKs[resource])
+	inst.SetNamespace(nsName)
+	inst.SetName(name)
+	inst.SetLabels(l)
+	ExpectWithOffset(1, K8sClient.Create(ctx, inst)).Should(Succeed())
+	createdObjects = append(createdObjects, inst)
+}
+
+// UpdateObjectWithAnnotations gets an object given it's kind, nsName and name, adds the annotation
 // and updates this object
-func UpdateObjectWithAnnotation(ctx context.Context, resource string, nsName,
+func UpdateObjectWithAnnotations(ctx context.Context, resource string, nsName,
 	name string, a map[string]string) error {
 	nnm := types.NamespacedName{Namespace: nsName, Name: name}
 	inst := &unstructured.Unstructured{}


### PR DESCRIPTION
The set of rules is hardcoded as of now, as proposed in #104. The current rules are Rancher-specific, as Rancher does some propagation of roles, rolebindings and serviceaccounts on its own via its "projects" (used to group namespaces). Label equality is checked against both key and value - no regex support for now.

Tested: addded a new test to check whether roles propagation is prevented if the label is matched; also checked, that this prevents propagation only for the specified groups / kinds.

---

I'm not really satisfied with hardcoding these, I personally would prefer a configurable solution. Unfortunately, I'm not sure how to best implement that.