### PR TITLE
Improve webhooks deny invalid fields

### DIFF
--- a/internal/webhooks/webhooks.go
+++ b/internal/webhooks/webhooks.go
@@ -6,8 +6,8 @@ import (
 
 	k8sadm "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -46,42 +46,33 @@ func Allow(msg string) admission.Response {
 // Deny is a replacement for controller-runtime's admission.Denied() that allows you to set _both_ a
 // human-readable message _and_ a machine-readable reason, and also sets the code correctly instead
 // of hardcoding it to 403 Forbidden.
+//
+// NOTE: When manipulating the HNC configuration object via kubectl directly, kubectl
+// ignores the Message field and displays the Details field if an error is
+// StatusReasonInvalid. For this reason DenyFromAPIError is preferred for denying
+// a request due to invalid data.
+//
+// Deprecated: Use DenyFromAPIError instead; please don't add new callers.
 func Deny(reason metav1.StatusReason, msg string) admission.Response {
-	return admission.Response{AdmissionResponse: k8sadm.AdmissionResponse{
-		Allowed: false,
-		Result: &metav1.Status{
+	err := &apierrors.StatusError{
+		ErrStatus: metav1.Status{
 			Code:    CodeFromReason(reason),
 			Message: msg,
 			Reason:  reason,
-		}},
+		},
 	}
+	return DenyFromAPIError(err)
 }
 
-// DenyInvalid is a wrapper for Deny with reason metav1.StatusReasonInvalid
-func DenyInvalid(field *field.Path, msg string) admission.Response {
-	// We need to set the custom message in both Details and Message fields.
-	//
-	// When manipulating the HNC configuration object via kubectl directly, kubectl
-	// ignores the Message field and displays the Details field if an error is
-	// StatusReasonInvalid (see implementation here: https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/util/helpers.go#L145-L160).
-	//
-	// When manipulating the HNC configuration object via the hns kubectl plugin,
-	// if an error is StatusReasonInvalid, only the Message field will be displayed. This is because
-	// the Error method (https://github.com/kubernetes/client-go/blob/cb664d40f84c27bee45c193e4acb0fcd549b0305/rest/request.go#L1273)
-	// calls FromObject (https://github.com/kubernetes/apimachinery/blob/7e441e0f246a2db6cf1855e4110892d1623a80cf/pkg/api/errors/errors.go#L100),
-	// which generates a StatusError (https://github.com/kubernetes/apimachinery/blob/7e441e0f246a2db6cf1855e4110892d1623a80cf/pkg/api/errors/errors.go#L35) object.
-	// *StatusError implements the Error interface using only the Message
-	// field (https://github.com/kubernetes/apimachinery/blob/7e441e0f246a2db6cf1855e4110892d1623a80cf/pkg/api/errors/errors.go#L49)).
-	// Therefore, when displaying the error, only the Message field will be available.
-	resp := Deny(metav1.StatusReasonInvalid, msg)
-	resp.Result.Details = &metav1.StatusDetails{
-		Causes: []metav1.StatusCause{{
-			Message: msg,
-			Field:   field.String(),
-		}},
+// DenyFromAPIError returns a response for denying a request with provided status error object.
+func DenyFromAPIError(apiStatus apierrors.APIStatus) admission.Response {
+	status := apiStatus.Status()
+	return admission.Response{
+		AdmissionResponse: k8sadm.AdmissionResponse{
+			Allowed: false,
+			Result:  &status,
+		},
 	}
-
-	return resp
 }
 
 // CodeFromReason implements the needed subset of


### PR DESCRIPTION
Started implementing https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/128, I realize that we currently have limited possibilities to report multiple invalid field validation errors in the same admission response. And with the quite detailed validation rules required for managed labels/annotations, I think we need an improvement. At least from an end-user perspective.

This PR suggests to replace https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/bfe42e2ec1c303709373d12d0b3d4d802b92c9c7/internal/webhooks/webhooks.go#L61 with a more generic DenyFromStatus inspired by existing code in controller-runtime (to support implementing high-level admission controllers), using errors/validations from api-machinery. This allows for aggregating multiple webhook validation errors of the same type (defined by statusCode), and should also IMO provide better error messages: Example: `HNCConfiguration.hnc.x-k8s.io \"config\" is invalid: spec.resources[0]: Invalid value: crontabs: not found in the apiserver with error: crontabs does not exist` instead of `Cannot find the crontabs in the apiserver with error: crontabs does not exist`

Also cleaning up some duplicated code I found when searching for for usages of `metav1.StatusReasonInvalid`.