### PR TITLE
Use DynamicRESTMapper to lookup metadata from apiserver

### DIFF
--- a/internal/apimeta/mapper.go
+++ b/internal/apimeta/mapper.go
@@ -1,0 +1,74 @@
+package apimeta
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NotNamespacedError is returned if the mapper can find the resource, but it is not namespaced.
+type NotNamespacedError struct {
+	GroupResource schema.GroupResource
+}
+
+func (e *NotNamespacedError) Error() string {
+	return fmt.Sprintf("resource %q is not namespaced", e.GroupResource)
+}
+
+func IsNotNamespacedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err.(type) {
+	case *NotNamespacedError:
+		return true
+	default:
+		return false
+	}
+}
+
+func NewGroupKindMapper(c *rest.Config) (*GroupKindMapper, error) {
+	restMapper, err := apiutil.NewDynamicRESTMapper(c)
+	if err != nil {
+		return nil, err
+	}
+	return &GroupKindMapper{
+		RestMapper: restMapper,
+	}, nil
+
+}
+
+// GroupKindMapper allows callers to map resources to kinds using apiserver metadata at runtime
+type GroupKindMapper struct {
+	RestMapper meta.RESTMapper
+}
+
+// NamespacedKindFor maps namespaced GR to GVK by using a DynamicRESTMapper
+// to discover resource types at runtime. Will return an error if the resource isn't namespaced.
+func (r *GroupKindMapper) NamespacedKindFor(gr schema.GroupResource) (schema.GroupVersionKind, error) {
+	resource := gr.WithVersion("")
+	kinds, err := r.RestMapper.KindsFor(resource)
+	if err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	// Not sure if this can ever happen? RestMapper.KindsFor does not specify if no
+	// matches will error out or not, so just making sure we do not get issues.
+	if len(kinds) == 0 {
+		return schema.GroupVersionKind{}, &meta.NoResourceMatchError{PartialResource: resource}
+	}
+
+	// KindsFor returns the list of potential kinds in priority order
+	gvk := kinds[0]
+	mapping, err := r.RestMapper.RESTMapping(gvk.GroupKind())
+	if err != nil {
+		return schema.GroupVersionKind{}, fmt.Errorf("while attempting to determine if kind is namespaced: %w", err)
+	}
+	if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
+		return schema.GroupVersionKind{}, &NotNamespacedError{GroupResource: gr}
+	}
+
+	return gvk, nil
+}

--- a/internal/hncconfig/reconciler_test.go
+++ b/internal/hncconfig/reconciler_test.go
@@ -301,7 +301,7 @@ var _ = Describe("HNCConfiguration", func() {
 		AddToHNCConfig(ctx, api.RBACGroup, "clusterroles", api.Propagate)
 
 		Eventually(GetHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonResourceNotNamespaced)).
-			Should(ContainSubstring("Resource \"clusterroles.rbac.authorization.k8s.io\" is not namespaced"))
+			Should(ContainSubstring("resource \"clusterroles.rbac.authorization.k8s.io\" is not namespaced"))
 	})
 
 	It("should set NumPropagatedObjects back to 0 after deleting the source object in propagate mode", func() {


### PR DESCRIPTION
This is mainly a refactoring of existing code, but modifies the internal machinery slightly. The initial motivation was to add more apiserver lookups to improve webhook validations in the `objects` package. Since the existing code performing similar stuff was private to the `hncconfig` package I had to do some changes anyway.

It turns out that controller-runtime provides a `DynamicRESTMapper`, that I think will fit very well in HNC for looking up resource information from the apiserver. HNC needs dynamic information in runtime, and that is exactly what this class provides. It also has some additional configuration features that can eventually be used in a follow-up PR.

Testing: Ran all tests locally with success, but I do not currently have a cluster available to test this change more. I expect it to work well, but doing changes to the machinery is always a bit risky.

/cc @adrianludwin 