### PR TITLE
Refactor webhook deny responses (cont)

### DIFF
--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -32,4 +32,11 @@ var (
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
+
+	HNCConfigurationGR       = schema.GroupResource{Group: GroupVersion.Group, Resource: "hncconfigurations"}
+	HierarchyConfigurationGR = schema.GroupResource{Group: GroupVersion.Group, Resource: "hierarchyconfigurations"}
+	SubnamespaceAnchorGR     = schema.GroupResource{Group: GroupVersion.Group, Resource: "subnamespaceanchors"}
+	HNCConfigurationGK       = schema.GroupKind{Group: GroupVersion.Group, Kind: "HNCConfiguration"}
+	HierarchyConfigurationGK = schema.GroupKind{Group: GroupVersion.Group, Kind: "HierarchyConfiguration"}
+	SubnamespaceAnchorGK     = schema.GroupKind{Group: GroupVersion.Group, Kind: "SubnamespaceAnchor"}
 )

--- a/internal/hierarchyconfig/validator_test.go
+++ b/internal/hierarchyconfig/validator_test.go
@@ -96,8 +96,8 @@ func TestStructure(t *testing.T) {
 	}{
 		{name: "ok", nnm: "a", pnm: "c"},
 		{name: "missing parent", nnm: "a", pnm: "brumpf", fail: true, msgContains: "does not exist"},
-		{name: "self-cycle", nnm: "a", pnm: "a", fail: true, msgContains: "Illegal parent"},
-		{name: "other cycle", nnm: "a", pnm: "b", fail: true, msgContains: "Illegal parent"},
+		{name: "self-cycle", nnm: "a", pnm: "a", fail: true, msgContains: "illegal parent"},
+		{name: "other cycle", nnm: "a", pnm: "b", fail: true, msgContains: "illegal parent"},
 		// Since we only set `kube-system` as excluded namespaces for this test, we
 		// should see denial message of excluded namespace for `kube-system`. As for
 		// `kube-public`, we will see missing parent/child instead of excluded

--- a/internal/objects/validator.go
+++ b/internal/objects/validator.go
@@ -2,6 +2,7 @@ package objects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -9,7 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	k8sadm "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -82,7 +83,7 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 
 	decoded, err := v.decodeRequest(log, req)
 	if err != nil {
-		return webhooks.Deny(metav1.StatusReasonBadRequest, err.Error())
+		return webhooks.DenyBadRequest(err)
 	}
 
 	// Run the actual logic.
@@ -118,23 +119,21 @@ func (v *Validator) handle(ctx context.Context, req *request) admission.Response
 	if !oldInherited && !newInherited {
 		// check if there is any invalid HNC annotation
 		if msg := validateSelectorAnnot(inst); msg != "" {
-			return webhooks.Deny(metav1.StatusReasonBadRequest, msg)
+			return webhooks.DenyBadRequest(errors.New(msg))
 		}
 		// check selector format
 		// If this is a selector change, and the new selector is not valid, we'll deny this operation
 		if err := validateSelectorChange(inst, oldInst); err != nil {
-			msg := fmt.Sprintf("Invalid Kubernetes labelSelector: %s", err)
-			return webhooks.Deny(metav1.StatusReasonBadRequest, msg)
+			return webhooks.DenyBadRequest(fmt.Errorf("invalid Kubernetes labelSelector: %w", err))
 		}
 		if err := validateTreeSelectorChange(inst, oldInst); err != nil {
-			msg := fmt.Sprintf("Invalid HNC %q value: %s", api.AnnotationTreeSelector, err)
-			return webhooks.Deny(metav1.StatusReasonBadRequest, msg)
+			return webhooks.DenyBadRequest(fmt.Errorf("invalid HNC %q value: %w", api.AnnotationTreeSelector, err))
 		}
 		if err := validateNoneSelectorChange(inst, oldInst); err != nil {
-			return webhooks.Deny(metav1.StatusReasonBadRequest, err.Error())
+			return webhooks.DenyBadRequest(err)
 		}
 		if msg := validateSelectorUniqueness(inst, oldInst); msg != "" {
-			return webhooks.Deny(metav1.StatusReasonBadRequest, msg)
+			return webhooks.DenyBadRequest(errors.New(msg))
 		}
 
 		if yes, dnses := v.hasConflict(inst); yes {
@@ -253,7 +252,7 @@ func (v *Validator) handleInherited(ctx context.Context, req *request, newSource
 		// namespace should be deleted, then don't block anything!
 		isDeleting, err := v.isDeletingNS(ctx, oldInst.GetNamespace())
 		if err != nil {
-			return webhooks.Deny(metav1.StatusReasonInternalError, "Cannot delete object propagated from namespace \""+oldSource+"\" with error: "+err.Error())
+			return webhooks.DenyInternalError(fmt.Errorf("cannot delete object propagated from namespace %s with error: %w", oldSource, err))
 		}
 
 		if !isDeleting {
@@ -289,7 +288,7 @@ func (v *Validator) handleInherited(ctx context.Context, req *request, newSource
 
 	// If you get here, it means the webhook config is misconfigured to include an operation that we
 	// actually don't support.
-	return webhooks.Deny(metav1.StatusReasonInternalError, "unknown operation: "+string(op))
+	return webhooks.DenyInternalError(fmt.Errorf("unknown operation: %s", op))
 }
 
 // validateDeletingNS validates if the namespace of the object is already being deleted
@@ -299,7 +298,7 @@ func (v *Validator) isDeletingNS(ctx context.Context, ns string) (bool, error) {
 	if err := v.client.Get(ctx, nnm, nsObj); err != nil {
 		// `IsNotFound` should never happen, but if for some bizarre reason the namespace appears to be deleted before the object,
 		// we should allow the object to be deleted too.
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, fmt.Errorf("while determining whether namespace %q is being deleted: %w", ns, err)


### PR DESCRIPTION
The goal of this PR is to eliminate callers to the recently deprecated generic `webhooks.Deny` internal function, and remove the function. I will prepare follow-up PR(s), where the ultimate goals is to provide the end-user with validation errors that:

- aggregates multiple validation errors if appropriate (and not the current fail-first behavior)
- are better structured and follows an established pattern in HNC
- are generally better aligned with standard Kubernetes validation errors

This is a continuation of https://github.com/kubernetes-sigs/hierarchical-namespaces/pull/132, that removes almost all callers to the generic `webhooks.Deny` func that got deprecated in this PR. Still some callers left in the "objects" validator, that I will fix in a follow-up PR after some required refactoring. This change is mainly refactoring existing code, but some error messages might change slightly.