### PR TITLE
Add liveness and startup/readiness probes

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,18 @@ spec:
         - "--excluded-namespace=kube-node-lease"
         image: controller:latest
         name: manager
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          failureThreshold: 1
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          failureThreshold: 100
+          periodSeconds: 5
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
This adds liveness and startup/readiness probes to the HNC Deployment using functionality recently added to controller-runtime. The probes configuration might need some adjustments of timeouts etc. to work without issues for a typical HNC deployment. The default configuration should probably be adjusted; timeouts etc., and should be tested in a live cluster - which I do not have available.

Testing: Ran all tests successfully on my local workstation, when using the simple ping probe. But when changing to the deeper webhook probe, the container never becomes ready. Seems to be an issue related to cert-rotator - which I do not know at all. We use cert-manager. HELP!

Fixes #68 

/kind feature
/cc @adrianludwin 