### PR TITLE
Introduce manager caching of Unstructured

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -224,6 +224,7 @@ func createManager() ctrl.Manager {
 	// it turns out to be harmful.
 	cfg.Burst = int(cfg.QPS * 1.5)
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		NewClient:              config.NewCachingClient,
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		HealthProbeBindAddress: probeAddr,

--- a/internal/config/cache_unstructured.go
+++ b/internal/config/cache_unstructured.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+)
+
+// NewCachingClient is an alternative implementation of controller-runtime's
+// default client for manager.Manager.
+// The only difference is that this implementation sets `CacheUnstructured` to `true` to
+// cache unstructured objects.
+func NewCachingClient(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
+	c, err := client.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.NewDelegatingClient(client.NewDelegatingClientInput{
+		CacheReader:       cache,
+		Client:            c,
+		UncachedObjects:   uncachedObjects,
+		CacheUnstructured: true,
+	})
+}
+
+var _ cluster.NewClientFunc = NewCachingClient

--- a/internal/integtest/setup.go
+++ b/internal/integtest/setup.go
@@ -37,6 +37,7 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 	"sigs.k8s.io/hierarchical-namespaces/internal/forest"
 	"sigs.k8s.io/hierarchical-namespaces/internal/setup"
 )
@@ -96,6 +97,7 @@ func HNCBeforeSuite() {
 
 	By("creating manager")
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		NewClient:          config.NewCachingClient,
 		MetricsBindAddress: "0", // disable metrics serving since 'go test' runs multiple suites in parallel processes
 		Scheme:             scheme.Scheme,
 	})
@@ -106,7 +108,8 @@ func HNCBeforeSuite() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Creating clients")
-	K8sClient = k8sManager.GetClient()
+	K8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
 	Expect(K8sClient).ToNot(BeNil())
 
 	go func() {


### PR DESCRIPTION
Caching of Unstructured is disabled by default in controller-runtime, and that is suboptimal for HNC which is reconciling generic objects configured by users.

Tested: Ran both unit-tests ('make test') and integration test ('make test-e2e') successfully.