### PR TITLE
Remove last callers of webhooks.Deny function and delete it

### DIFF
--- a/internal/webhooks/webhooks.go
+++ b/internal/webhooks/webhooks.go
@@ -74,26 +74,6 @@ func DenyUnauthorized(reason string) admission.Response {
 	return denyFromAPIError(apierrors.NewUnauthorized(reason))
 }
 
-// Deny is a replacement for controller-runtime's admission.Denied() that allows you to set _both_ a
-// human-readable message _and_ a machine-readable reason, and also sets the code correctly instead
-// of hardcoding it to 403 Forbidden.
-//
-// NOTE: When manipulating the HNC configuration object via kubectl directly, kubectl
-// ignores the Message field and displays the Details field if an error is
-// StatusReasonInvalid.
-//
-// Deprecated: Use one of the explicit deny reason funcs instead; please don't add new callers.
-func Deny(reason metav1.StatusReason, msg string) admission.Response {
-	err := &apierrors.StatusError{
-		ErrStatus: metav1.Status{
-			Code:    CodeFromReason(reason),
-			Message: msg,
-			Reason:  reason,
-		},
-	}
-	return denyFromAPIError(err)
-}
-
 // denyFromAPIError returns a response for denying a request with provided status error object.
 func denyFromAPIError(apiStatus apierrors.APIStatus) admission.Response {
 	status := apiStatus.Status()
@@ -102,30 +82,5 @@ func denyFromAPIError(apiStatus apierrors.APIStatus) admission.Response {
 			Allowed: false,
 			Result:  &status,
 		},
-	}
-}
-
-// CodeFromReason implements the needed subset of
-// https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#StatusReason
-func CodeFromReason(reason metav1.StatusReason) int32 {
-	switch reason {
-	case metav1.StatusReasonUnknown:
-		return 500
-	case metav1.StatusReasonUnauthorized:
-		return 401
-	case metav1.StatusReasonForbidden:
-		return 403
-	case metav1.StatusReasonConflict:
-		return 409
-	case metav1.StatusReasonBadRequest:
-		return 400
-	case metav1.StatusReasonInvalid:
-		return 422
-	case metav1.StatusReasonInternalError:
-		return 500
-	case metav1.StatusReasonServiceUnavailable:
-		return 503
-	default:
-		return 500
 	}
 }


### PR DESCRIPTION
Some error messages are slightly modified, in particular one error message that were formatted across multiple lines.

Tested: Ran both unit-tests ('make test') and integration test ('make test-e2e') successfully. ~~After the controller probes PR got merged, I am sadly no longer able to run integration test ('make test-e2e'). The pod is just crash looping. :-(~~