### PR TITLE
Install Kind via 'go install'

### DIFF
--- a/hack/prow-run-e2e.sh
+++ b/hack/prow-run-e2e.sh
@@ -33,7 +33,7 @@ echo "Starting script at $(date +%Y-%m-%d\ %H:%M:%S)"
 # as of Go 1.15, GO111MODULE=on *is* required.
 echo
 echo Installing and starting Kind...
-(cd && GO111MODULE=on go get sigs.k8s.io/kind@v0.9.0)
+go install sigs.k8s.io/kind@v0.12.0
 kind create cluster
 
 echo


### PR DESCRIPTION
Postsubmits and periodics are failing with a message to use 'go
install', so trying that. Also upgrading to lastest Kind version at the
same time.

Tested: none, no real way to test without submitting, plus all the tests
are currently broken anyway so can't make things worse.