### PR TITLE
Add readiness probe

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,6 +67,11 @@ spec:
             port: 8081
           failureThreshold: 1
           periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          periodSeconds: 5
         startupProbe:
           httpGet:
             path: /readyz


### PR DESCRIPTION
On GKE 1.21 and earlier, I noticed HNC taking a long time (~80s) to
become Ready (for more details, see #170). Adding a readiness probe
fixes the problem.

Tested: before this change, on GKE 1.20 and 1.21, I manually see HNC
taking a long time to start, and the e2e tests that require reinstalling
HNC fail because it the deadlines are exceeded. With this change, I can
see HNC becoming ready in ~10s on GKE 1.20 and all the e2e tests pass.

Fixes #170 