### PR TITLE
Add security context

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    pod-security.kubernetes.io/enforce: restricted  
+    pod-security.kubernetes.io/enforce-version: v1.23
   name: system
 ---
 apiVersion: apps/v1
@@ -57,6 +59,14 @@ spec:
         - containerPort: 8080
           name: metrics
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert


### PR DESCRIPTION
Fixes #181
Tested: test-smoke, test-e2e

```
go clean --testcache
go test -v -timeout 0 ./test/e2e/... -args --ginkgo.focus "Quickstart"
=== RUN   TestE2e
Running Suite: HNC Suite
========================
Random Seed: 1650309465
Will run 5 of 36 specs

SSSSSSSSSSSSSSSSSS
------------------------------
• [SLOW TEST:30.375 seconds]
Quickstart
/home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:11
  Should test basic functionalities in quickstart
  /home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:33
------------------------------
• [SLOW TEST:30.292 seconds]
Quickstart
/home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:11
  Should propagate different types
  /home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:81
------------------------------

S [SKIPPING] [67.745 seconds]
Quickstart
/home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:11
  Should integrate hierarchical network policy [It]
  /home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:105

  Basic network policies don't appear to be working; skipping the netpol quickstart

  /home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:165
------------------------------
• [SLOW TEST:62.344 seconds]
Quickstart
/home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:11
  Should create and delete subnamespaces
  /home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:194
------------------------------


• [SLOW TEST:22.588 seconds]
Quickstart
/home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:11
  Should demonstrate exceptions
  /home/romang/Documents/hierarchical-namespaces/test/e2e/quickstart_test.go:253
------------------------------
SSSSSSSSSSSSS

Ran 4 of 36 Specs in 213.345 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 32 Skipped
```