### PR TITLE
Validate subnamespace anchors on update (backporting to v1.0 branch)

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -48,6 +48,7 @@ webhooks:
     - v1alpha2
     operations:
     - CREATE
+    - UPDATE
     - DELETE
     resources:
     - subnamespaceanchors

--- a/internal/anchor/validator.go
+++ b/internal/anchor/validator.go
@@ -27,7 +27,7 @@ const (
 // Note: the validating webhook FAILS CLOSE. This means that if the webhook goes down, all further
 // changes are forbidden.
 //
-// +kubebuilder:webhook:admissionReviewVersions=v1,path=/validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchors,mutating=false,failurePolicy=fail,groups="hnc.x-k8s.io",resources=subnamespaceanchors,sideEffects=None,verbs=create;delete,versions=v1alpha2,name=subnamespaceanchors.hnc.x-k8s.io
+// +kubebuilder:webhook:admissionReviewVersions=v1,path=/validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchors,mutating=false,failurePolicy=fail,groups="hnc.x-k8s.io",resources=subnamespaceanchors,sideEffects=None,verbs=create;update;delete,versions=v1alpha2,name=subnamespaceanchors.hnc.x-k8s.io
 
 type Validator struct {
 	Log     logr.Logger


### PR DESCRIPTION
Now that labels and annotations can be added to subnamespace anchors, these should now also be validated when they are updated.

Tested: before this change on K8s 1.16 I was able to modify the labels on subnamespace anchors without any validation running. With this change my modification is now validated and blocked.
