### PR TITLE
Disable HRQ e2e tests

### DIFF
--- a/test/e2e/hrq_test.go
+++ b/test/e2e/hrq_test.go
@@ -27,7 +27,8 @@ const (
 	resourceQuotaSingleton = "hrq.hnc.x-k8s.io"
 )
 
-var _ = Describe("Hierarchical Resource Quota", func() {
+// HRQ tests are pending (disabled) until we turn them on in all the default manifests
+var _ = PDescribe("Hierarchical Resource Quota", func() {
 	BeforeEach(func() {
 		rand.Seed(time.Now().UnixNano())
 		CleanupTestNamespaces()


### PR DESCRIPTION
HRQ isn't on in the default manifests so we shouldn't try to test it.

Tested: verified that the right number tests are "pending" when I run
`make test-e2e`. Didn't wait to verify exactly which ones they were.