### PR TITLE
Inclusive configuration of resources to propagate

### DIFF
--- a/api/v1alpha2/hierarchy_types.go
+++ b/api/v1alpha2/hierarchy_types.go
@@ -37,6 +37,7 @@ const (
 	AnnotationSelector     = AnnotationPropagatePrefix + "/select"
 	AnnotationTreeSelector = AnnotationPropagatePrefix + "/treeSelect"
 	AnnotationNoneSelector = AnnotationPropagatePrefix + "/none"
+	AnnotationAllSelector  = AnnotationPropagatePrefix + "/all"
 
 	// LabelManagedByStandard will eventually replace our own managed-by annotation (we didn't know
 	// about this standard label when we invented our own).

--- a/api/v1alpha2/hnc_config.go
+++ b/api/v1alpha2/hnc_config.go
@@ -31,7 +31,7 @@ const (
 )
 
 // SynchronizationMode describes propagation mode of objects of the same kind.
-// The only three modes currently supported are "Propagate", "Ignore", and "Remove".
+// The only four modes currently supported are "Propagate", "AllowPropagate", "Ignore", and "Remove".
 // See detailed definition below. An unsupported mode will be treated as "ignore".
 type SynchronizationMode string
 
@@ -46,6 +46,10 @@ const (
 
 	// Remove all existing propagated copies.
 	Remove SynchronizationMode = "Remove"
+
+	// AllowPropagate allows propagation of objects from ancestors to descendants
+	// and deletes obsolete descendants only if a an annotation is set on the object
+	AllowPropagate SynchronizationMode = "AllowPropagate"
 )
 
 const (
@@ -94,7 +98,7 @@ type ResourceSpec struct {
 	// Synchronization mode of the kind. If the field is empty, it will be treated
 	// as "Propagate".
 	// +optional
-	// +kubebuilder:validation:Enum=Propagate;Ignore;Remove
+	// +kubebuilder:validation:Enum=Propagate;Ignore;Remove;AllowPropagate
 	Mode SynchronizationMode `json:"mode,omitempty"`
 }
 

--- a/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
+++ b/config/crd/bases/hnc.x-k8s.io_hncconfigurations.yaml
@@ -64,6 +64,7 @@ spec:
                       - Propagate
                       - Ignore
                       - Remove
+                      - AllowPropagate
                       type: string
                     resource:
                       description: Resource to be configured.

--- a/internal/forest/forest.go
+++ b/internal/forest/forest.go
@@ -51,6 +51,9 @@ type TypeSyncer interface {
 	// GetMode gets the propagation mode of objects that are handled by the reconciler who implements the interface.
 	GetMode() api.SynchronizationMode
 
+	// CanPropagate returns true if Propagate mode or AllowPropagate mode is set
+	CanPropagate() bool
+
 	// GetNumPropagatedObjects returns the number of propagated objects on the apiserver.
 	GetNumPropagatedObjects() int
 }

--- a/internal/hncconfig/reconciler.go
+++ b/internal/hncconfig/reconciler.go
@@ -361,7 +361,7 @@ func (r *Reconciler) writeCondition(inst *api.HNCConfiguration, tp, reason, msg 
 }
 
 // setTypeStatuses adds Status.Resources for types configured in the spec. Only the status of types
-// in `Propagate` and `Remove` modes will be recorded. The Status.Resources is sorted in
+// in `Propagate`, `Remove` and `AllowPropagate` modes will be recorded. The Status.Resources is sorted in
 // alphabetical order based on Group and Resource.
 func (r *Reconciler) setTypeStatuses(inst *api.HNCConfiguration) {
 	// We lock the forest here so that other reconcilers cannot modify the
@@ -394,7 +394,7 @@ func (r *Reconciler) setTypeStatuses(inst *api.HNCConfiguration) {
 		}
 
 		// Only add NumSourceObjects if we are propagating objects of this type.
-		if ts.GetMode() == api.Propagate {
+		if ts.CanPropagate() {
 			numSrc := 0
 			nms := r.Forest.GetNamespaceNames()
 			for _, nm := range nms {

--- a/internal/kubectl/configdescribe.go
+++ b/internal/kubectl/configdescribe.go
@@ -37,6 +37,8 @@ var configDescribeCmd = &cobra.Command{
 				action = "Propagating"
 			case api.Remove:
 				action = "Removing"
+			case api.AllowPropagate:
+				action = "AllowPropagate"
 			default:
 				action = "Ignoring"
 			}

--- a/internal/objects/validator.go
+++ b/internal/objects/validator.go
@@ -79,10 +79,10 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 	if !config.IsManagedNamespace(req.Namespace) {
 		return webhooks.Allow("unmanaged namespace " + req.Namespace)
 	}
-	// Allow changes to the types that are not in propagate mode. This is to dynamically enable/disable
+	// Allow changes to the types that are not in Propagate or AllowPropagate mode. This is to dynamically enable/disable
 	// object webhooks based on the types configured in hncconfig. Since the current admission rules only
 	// apply to propagated objects, we can disable object webhooks on all other non-propagate-mode types.
-	if !v.isPropagateType(req.Kind) {
+	if !v.canPropagateType(req.Kind) {
 		return webhooks.Allow("Non-propagate-mode types")
 	}
 	// Finally, let the HNC SA do whatever it wants.
@@ -106,12 +106,26 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 	return resp
 }
 
+func (v *Validator) syncType(gvk metav1.GroupVersionKind) api.SynchronizationMode {
+	ts := v.Forest.GetTypeSyncerFromGroupKind(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind})
+	if ts == nil {
+		return api.Ignore
+	}
+	return ts.GetMode()
+}
+
 func (v *Validator) isPropagateType(gvk metav1.GroupVersionKind) bool {
+	return v.syncType(gvk) == api.Propagate
+}
+
+func (v *Validator) isAllowPropagateType(gvk metav1.GroupVersionKind) bool {
+	return v.syncType(gvk) == api.AllowPropagate
+}
+
+func (v *Validator) canPropagateType(gvk metav1.GroupVersionKind) bool {
 	v.Forest.Lock()
 	defer v.Forest.Unlock()
-
-	ts := v.Forest.GetTypeSyncerFromGroupKind(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind})
-	return ts != nil && ts.GetMode() == api.Propagate
+	return (v.isPropagateType(gvk) || v.isAllowPropagateType(gvk))
 }
 
 // handle implements the non-webhook-y businesss logic of this validator, allowing it to be more
@@ -142,6 +156,9 @@ func (v *Validator) handle(ctx context.Context, req *request) admission.Response
 		if err := validateNoneSelectorChange(inst, oldInst); err != nil {
 			return webhooks.DenyBadRequest(err)
 		}
+		if err := validateAllSelectorChange(inst, oldInst); err != nil {
+			return webhooks.DenyBadRequest(err)
+		}
 		if msg := validateSelectorUniqueness(inst, oldInst); msg != "" {
 			return webhooks.DenyBadRequest(errors.New(msg))
 		}
@@ -168,8 +185,10 @@ func validateSelectorAnnot(inst *unstructured.Unstructured) string {
 			continue
 		}
 		msg := "invalid HNC exceptions annotation: %v, should be one of the following: " +
-			api.AnnotationSelector + "; " + api.AnnotationTreeSelector + "; " +
-			api.AnnotationNoneSelector
+			api.AnnotationSelector +
+			"; " + api.AnnotationTreeSelector +
+			"; " + api.AnnotationNoneSelector +
+			"; " + api.AnnotationAllSelector
 		// If this annotation is part of HNC metagroup, we check if the prefix value is valid
 		if segs[0] != api.AnnotationPropagatePrefix {
 			return fmt.Sprintf(msg, key)
@@ -177,7 +196,8 @@ func validateSelectorAnnot(inst *unstructured.Unstructured) string {
 		// check if the suffix is valid by checking the whole annotation key
 		if key != api.AnnotationSelector &&
 			key != api.AnnotationTreeSelector &&
-			key != api.AnnotationNoneSelector {
+			key != api.AnnotationNoneSelector &&
+			key != api.AnnotationAllSelector {
 			return fmt.Sprintf(msg, key)
 		}
 	}
@@ -188,12 +208,14 @@ func validateSelectorUniqueness(inst, oldInst *unstructured.Unstructured) string
 	sel := selectors.GetSelectorAnnotation(inst)
 	treeSel := selectors.GetTreeSelectorAnnotation(inst)
 	noneSel := selectors.GetNoneSelectorAnnotation(inst)
+	allSel := selectors.GetAllSelectorAnnotation(inst)
 
 	oldSel := selectors.GetSelectorAnnotation(oldInst)
 	oldTreeSel := selectors.GetTreeSelectorAnnotation(oldInst)
 	oldNoneSel := selectors.GetNoneSelectorAnnotation(oldInst)
+	oldAllSel := selectors.GetAllSelectorAnnotation(oldInst)
 
-	isSelectorChange := oldSel != sel || oldTreeSel != treeSel || oldNoneSel != noneSel
+	isSelectorChange := oldSel != sel || oldTreeSel != treeSel || oldNoneSel != noneSel || oldAllSel != allSel
 	if !isSelectorChange {
 		return ""
 	}
@@ -206,6 +228,9 @@ func validateSelectorUniqueness(inst, oldInst *unstructured.Unstructured) string
 	}
 	if noneSel != "" {
 		found = append(found, api.AnnotationNoneSelector)
+	}
+	if allSel != "" {
+		found = append(found, api.AnnotationAllSelector)
 	}
 	if len(found) <= 1 {
 		return ""
@@ -241,6 +266,16 @@ func validateNoneSelectorChange(inst, oldInst *unstructured.Unstructured) error 
 		return nil
 	}
 	_, err := selectors.GetNoneSelector(inst)
+	return err
+}
+
+func validateAllSelectorChange(inst, oldInst *unstructured.Unstructured) error {
+	oldSelectorStr := selectors.GetAllSelectorAnnotation(oldInst)
+	newSelectorStr := selectors.GetAllSelectorAnnotation(inst)
+	if newSelectorStr == "" || oldSelectorStr == newSelectorStr {
+		return nil
+	}
+	_, err := selectors.GetAllSelector(inst)
 	return err
 }
 
@@ -347,7 +382,8 @@ func (v *Validator) hasConflict(inst *unstructured.Unstructured) (bool, []string
 			// If the user have chosen not to propagate the object to this descendant,
 			// there shouldn't be any conflict reported here
 			nsLabels := v.Forest.Get(inst.GetNamespace()).GetLabels()
-			if ok, _ := selectors.ShouldPropagate(inst, nsLabels); ok {
+			mode := v.syncType(metav1.GroupVersionKind(gvk))
+			if ok, _ := selectors.ShouldPropagate(inst, nsLabels, mode); ok {
 				conflicts = append(conflicts, desc)
 			}
 		}

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -276,6 +276,12 @@ func CleanupTestNamespaces() {
 	cleanupNamespaces(nses...)
 }
 
+// CleanupTestResourceSyncMode changes the synchronization mode of resources
+// used in testing back to its default value
+func CleanupTestResourceSyncMode() {
+	MustRun("kubectl hns config set-resource secrets --mode Ignore")
+}
+
 // CleanupCRDIfExists checks whether the eetests.e2e.hnc.x-k8s.io CRD is present, if so, delete it.
 func CleanupTestCRDIfExists() {
 	crd := "eetests.e2e.hnc.x-k8s.io"

--- a/test/e2e/kubectl_test.go
+++ b/test/e2e/kubectl_test.go
@@ -6,11 +6,16 @@ import (
 )
 
 var _ = Describe("HNS set-config", func() {
-	It("Should use '--force' flag to change from 'Ignore' to 'Propagate'", func() {
+	It("Should use '--force' flag to change from 'Ignore' to 'Propagate' or 'AllowPropagate'", func() {
 		MustRun("kubectl hns config set-resource secrets --mode Ignore")
+
 		MustNotRun("kubectl hns config set-resource secrets --mode Propagate")
 		MustRun("kubectl hns config set-resource secrets --mode Propagate --force")
 		// check that we don't need '--force' flag when changing it back
+		MustRun("kubectl hns config set-resource secrets --mode Ignore")
+
+		MustNotRun("kubectl hns config set-resource secrets --mode AllowPropagate")
+		MustRun("kubectl hns config set-resource secrets --mode AllowPropagate --force")
 		MustRun("kubectl hns config set-resource secrets --mode Ignore")
 	})
 })


### PR DESCRIPTION
Addresses #16. As suggested in the issue, an additional SyncornizationMode called `Allow` is added (and not `AllowPropagate` to allow the kubetcl plugin keep the same logic of converting the strings to Title).

Allow only allows propagation of objects when a selector is set. When a selector is set, `Allow` follows the same logic as `Propagate`. When no selectors are set, the object is not propagated.

In addition, an `all` selector is added.

New unit testing and e2e testing were made for this mode and for the new selector.

The documentation and quickstart testing are left untouched.