### PR TITLE
Subtree usage updated when namespace is removed from subtree

### DIFF
--- a/internal/hrq/rqreconciler.go
+++ b/internal/hrq/rqreconciler.go
@@ -202,8 +202,7 @@ func (r *ResourceQuotaReconciler) deleteSingleton(ctx context.Context, log logr.
 //   and its ancestors.
 // - Updates `hrq.used.local` of the current namespace and `hrq.used.subtree`
 //   of the current namespace and its ancestors based on `ResourceQuota.Status.Used`.
-func (r *ResourceQuotaReconciler) syncWithForest(log logr.Logger,
-	inst *v1.ResourceQuota) bool {
+func (r *ResourceQuotaReconciler) syncWithForest(log logr.Logger, inst *v1.ResourceQuota) bool {
 	r.Forest.Lock()
 	defer r.Forest.Unlock()
 	ns := r.Forest.Get(inst.ObjectMeta.Namespace)

--- a/internal/setup/reconcilers.go
+++ b/internal/setup/reconcilers.go
@@ -89,6 +89,7 @@ func CreateReconcilers(mgr ctrl.Manager, f *forest.Forest, opts Options) error {
 			RQR:    rqr,
 		}
 		rqr.HRQR = hrqr
+		f.AddListener(hrqr)
 
 		if err := rqr.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("cannot create resource quota reconciler: %s", err.Error())


### PR DESCRIPTION
See issue #214. Previously, when the parent of the full namespace
in a subtree was changed, the subtree usage was not properly updated and the
usgae in the HRQ object was not accounting for the decrease in usage.
In this fix, when a parent changes, the local usage of resources is
zeroed and the subtree usage is recalculated without the full namespace usage.

Tested: e2e-testing covering a scenario where a full namespace is the child
of a subnamespace and when the full namespace's parents is changed to root,
the subtree usages is checked to make sure it is correct.

Signed-off-by: mzeevi <meytar80@gmail.com>