### PR TITLE
Refactor some HRQ code for readability

### DIFF
--- a/internal/hrq/hrqreconciler.go
+++ b/internal/hrq/hrqreconciler.go
@@ -141,15 +141,9 @@ func (r *HierarchicalResourceQuotaReconciler) syncUsages(inst *api.HierarchicalR
 	}
 	ns := r.Forest.Get(inst.GetNamespace())
 
-	// Get all usage counts in this namespace
-	usages := ns.GetSubtreeUsages()
-
-	// Get the names of all resource types being limited by this particular HRQ
-	nms := utils.ResourceNames(inst.Spec.Hard)
-
 	// Filter the usages to only include the resource types being limited by this HRQ and write those
 	// usages back to the HRQ status.
-	inst.Status.Used = utils.Mask(usages, nms)
+	inst.Status.Used = utils.FilterUnlimited(ns.GetSubtreeUsages(), inst.Spec.Hard)
 }
 
 func isDeleted(inst *api.HierarchicalResourceQuota) bool {

--- a/internal/hrq/hrqreconciler_test.go
+++ b/internal/hrq/hrqreconciler_test.go
@@ -230,7 +230,7 @@ var _ = Describe("HRQ reconciler tests", func() {
 func forestSetSubtreeUsages(ns string, args ...string) {
 	TestForest.Lock()
 	defer TestForest.Unlock()
-	TestForest.Get(ns).UpdateSubtreeUsages(argsToResourceList(0, args...))
+	TestForest.Get(ns).TestOnlySetSubtreeUsage(argsToResourceList(0, args...))
 }
 
 func getHRQStatus(ctx context.Context, ns, nm string) func() v1.ResourceList {

--- a/internal/hrq/utils/resources_test.go
+++ b/internal/hrq/utils/resources_test.go
@@ -225,39 +225,6 @@ func TestSubtract(t *testing.T) {
 	}
 }
 
-func TestCopy(t *testing.T) {
-	tests := []struct {
-		name string
-		in   v1.ResourceList
-		want v1.ResourceList
-	}{
-		{
-			name: "noKeys",
-			in:   v1.ResourceList{},
-			want: v1.ResourceList{},
-		},
-		{
-			name: "hasKeys",
-			in: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("100m"),
-				v1.ResourceMemory: resource.MustParse("1Gi"),
-				v1.ResourcePods:   resource.MustParse("1")},
-			want: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("100m"),
-				v1.ResourceMemory: resource.MustParse("1Gi"),
-				v1.ResourcePods:   resource.MustParse("1")},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := Copy(tc.in)
-			if result := Equals(tc.want, got); !result {
-				t.Errorf("%s want: %v, got: %v", tc.name, tc.want, got)
-			}
-		})
-	}
-}
-
 func TestMin(t *testing.T) {
 	type inputs struct {
 		a v1.ResourceList
@@ -365,53 +332,11 @@ func TestResourceNames(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got := ResourceNames(tc.in)
+		got := resourceNames(tc.in)
 		sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
 		sort.Slice(tc.want, func(i, j int) bool { return tc.want[i] < tc.want[j] })
 
 		if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("%s expected: %v, actual: %v", tc.name, tc.want, got)
-		}
-	}
-}
-
-func TestContains(t *testing.T) {
-	type inputs struct {
-		a []v1.ResourceName
-		b v1.ResourceName
-	}
-	tests := []struct {
-		name string
-		in   inputs
-		want bool
-	}{
-		{
-			name: "empty slice",
-			in: inputs{
-				a: []v1.ResourceName{},
-				b: v1.ResourceCPU,
-			},
-			want: false,
-		},
-		{
-			name: "does not contain",
-			in: inputs{
-				a: []v1.ResourceName{v1.ResourceMemory},
-				b: v1.ResourceCPU,
-			},
-			want: false,
-		},
-		{
-			name: "contains",
-			in: inputs{
-				a: []v1.ResourceName{v1.ResourceMemory, v1.ResourceCPU},
-				b: v1.ResourceCPU,
-			},
-			want: true,
-		},
-	}
-	for _, tc := range tests {
-		if got := Contains(tc.in.a, tc.in.b); got != tc.want {
 			t.Errorf("%s expected: %v, actual: %v", tc.name, tc.want, got)
 		}
 	}
@@ -475,7 +400,7 @@ func TestMask(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		if got := Mask(tc.in.a, tc.in.b); !Equals(tc.want, got) {
+		if got := mask(tc.in.a, tc.in.b); !Equals(tc.want, got) {
 			t.Errorf("%s expected: %v, actual: %v", tc.name, tc.want, got)
 		}
 	}
@@ -520,7 +445,7 @@ func TestToSet(t *testing.T) {
 	}
 }
 
-func TestCleanupUnneeded(t *testing.T) {
+func TestFilterUnlimited(t *testing.T) {
 	tests := []struct {
 		name   string
 		usages v1.ResourceList
@@ -568,7 +493,7 @@ func TestCleanupUnneeded(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := CleanupUnneeded(tc.usages, tc.limits)
+			got := FilterUnlimited(tc.usages, tc.limits)
 			if result := Equals(tc.want, got); !result {
 				t.Errorf("%s want: %v, got: %v", tc.name, tc.want, got)
 			}


### PR DESCRIPTION
I found some of this code very difficult to read, and there was a bunch of stuff in the 'utils' package that was being exported but not used (this is because the library was originally copied from K8s, but it's been heavily modified since then). Hopefully others find these cleanups useful to.

I did simplify the TryUseResources function to allow decreasing usage. This opens up a *very* slight race condition at the cost of making the function more robust to future changes in K8s and significantly easier to understand and test.