### PR TITLE
doc(quickstart): add `AllowPropagate` as a option for synchronization mode

### DIFF
--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -209,8 +209,8 @@ simply use the config subcommand:
 kubectl hns config set-resource secrets --mode Propagate
 ```
 
-  Note: As of HNC v0.9+, the supported modes are `Propagate`, `Remove` and
-  `Ignore`. More may be added in the future; you can run `kubectl hns config
+  Note: As of HNC v1.0+, the supported modes are `Propagate`, `Remove`,
+  `Ignore` and `AllowPropagate`. More may be added in the future; you can run `kubectl hns config
   set-resource` for the latest documentation.
 
 Now, we should be able to verify that `my-creds` was propagated to `service-1`:


### PR DESCRIPTION
/kind documentation
/kind cleanup

`AllowPropagete` is available in the option.
https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/ec50308b39ae6ba63db6f34422639d4595fab880/internal/kubectl/configset.go#L81