### PR TITLE
Add periodic HRQ resync

### DIFF
--- a/internal/integtest/setup.go
+++ b/internal/integtest/setup.go
@@ -51,10 +51,6 @@ var (
 	TestForest         *forest.Forest
 )
 
-const (
-	HRQSyncInterval = 5 * time.Second
-)
-
 func HNCRun(t *testing.T, title string) {
 	RunSpecs(t, title)
 }
@@ -107,11 +103,10 @@ func HNCBeforeSuite() {
 
 	By("creating reconcilers")
 	opts := setup.Options{
-		MaxReconciles:   100,
-		UseFakeClient:   true,
-		HNCCfgRefresh:   1 * time.Second, // so we don't have to wait as long
-		HRQ:             true,
-		HRQSyncInterval: HRQSyncInterval,
+		MaxReconciles: 100,
+		UseFakeClient: true,
+		HNCCfgRefresh: 1 * time.Second, // so we don't have to wait as long
+		HRQ:           true,
 	}
 	TestForest = forest.NewForest()
 	err = setup.CreateReconcilers(k8sManager, TestForest, opts)
@@ -139,4 +134,8 @@ func HNCAfterSuite() {
 	Expect(testEnv).ToNot(BeNil())
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
+}
+
+func TestCheckHRQDrift() bool {
+	return setup.TestOnlyCheckHRQDrift(TestForest)
 }


### PR DESCRIPTION
If the HRQ logic is correct, the incremental updates should always work, but there's always the chance of a bug, so add a periodic (1m by default) recalculation from scratch to ensure that the incremental updates are working correctly. If a discrepancy is found, it dumps an error in the log and updates the HRQs to the correct values.

Tested: broke the checker in various ways and ensured that the integ test failed.

Fixes #189 