### PR TITLE
Do not propagate Helm release Secrets

### DIFF
--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -377,6 +377,7 @@ objects from being propagated by HNC.
 * *Planned for HNC v1.0+:* Any objects with the label
   `cattle.io/creator:norman`, which are [inserted by Rancher to support
   Projects](https://rancher.com/docs/rancher/v2.6/en/system-tools/#remove))
+* *Planned for future version:* Secrets with type `helm.sh/release.v1`, which is auto-created in the namespaces where their respective Helm releases are deployed to.
 
 <a name="admin"/>
 

--- a/internal/integtest/helpers.go
+++ b/internal/integtest/helpers.go
@@ -327,6 +327,17 @@ func MakeObjectWithLabels(ctx context.Context, resource string, nsName,
 	createdObjects = append(createdObjects, inst)
 }
 
+// MakeSecrettWithType creates an empty Secret with type given kind in a specific namespace.
+func MakeSecrettWithType(ctx context.Context, nsName, name, scType string) {
+	inst := &unstructured.Unstructured{}
+	inst.SetGroupVersionKind(GVKs["secrets"])
+	inst.SetNamespace(nsName)
+	inst.SetName(name)
+	inst.UnstructuredContent()["type"] = scType
+	ExpectWithOffset(1, K8sClient.Create(ctx, inst)).Should(Succeed())
+	createdObjects = append(createdObjects, inst)
+}
+
 // UpdateObjectWithAnnotations gets an object given it's kind, nsName and name, adds the annotation
 // and updates this object
 func UpdateObjectWithAnnotations(ctx context.Context, resource, nsName, name string, a map[string]string) {

--- a/internal/objects/reconciler_test.go
+++ b/internal/objects/reconciler_test.go
@@ -435,6 +435,17 @@ var _ = Describe("Basic propagation", func() {
 		Eventually(HasObject(ctx, "configmaps", barName, "kube-root-ca.crt")).Should(BeFalse())
 	})
 
+	It("should not propagate builtin exclusions by Secret Type", func() {
+		SetParent(ctx, barName, fooName)
+		MakeSecrettWithType(ctx, fooName, "gets-propagated", "Opaque")
+		MakeSecrettWithType(ctx, fooName, "helm-secret", "helm.sh/release.v1")
+		AddToHNCConfig(ctx, "", "secrets", api.Propagate)
+
+		// We expect normal secrets to be propagated, but builtin exclusions not to be.
+		Eventually(HasObject(ctx, "secrets", barName, "gets-propagated")).Should(BeTrue())
+		Eventually(HasObject(ctx, "secrets", barName, "helm-secret")).Should(BeFalse())
+	})
+
 	It("should not propagate builtin exclusions by labels", func() {
 		SetParent(ctx, barName, fooName)
 		MakeObjectWithLabels(ctx, "roles", fooName, "role-with-labels-blocked", map[string]string{"cattle.io/creator": "norman"})

--- a/internal/selectors/selectors.go
+++ b/internal/selectors/selectors.go
@@ -222,11 +222,22 @@ var exclusionByAnnotations = []ExclusionByAnnotationsSpec{
 	{Key: "openshift.io/description"},
 }
 
+// scExclusionsByType are known (Helm) type of Secret which are excluded from propagation.
+var scExclusionsByType = []string{"helm.sh/release.v1"}
+
 // isExcluded returns true to indicate that this object is excluded from being propagated
 func isExcluded(inst *unstructured.Unstructured) (bool, error) {
 	name := inst.GetName()
 	kind := inst.GetKind()
 	group := inst.GroupVersionKind().Group
+
+	// exclusion by Secret type
+	for _, excludedSecretType := range scExclusionsByType {
+		if group == "" && kind == "Secret" && inst.UnstructuredContent()["type"] == excludedSecretType {
+			return true, nil
+		}
+	}
+
 	// exclusion by name
 	for _, excludedResourceName := range cmExclusionsByName {
 		if group == "" && kind == "ConfigMap" && name == excludedResourceName {


### PR DESCRIPTION
## What type of PR is this?:
/kind feature
/kind documentation

## What this PR does / why we need it:
Added Secrets of Type `helm.sh/release.v1` to built-in exceptions.

## Tested:
Added new unit test for my change; verified that the test passed.

## Which issue(s) this PR fixes:
#241

## Special notes for your reviewer:
This PR includes documentation fix to add this feature to Built-in exceptions section.
In this section, I wrote *Planned for future version:* because I'm not sure when this feature will be released.
If you have any plan, please tell me and I'll rewite the sentence.