### PR TITLE
Remove useless lines related to unit test

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,9 +53,6 @@ accessible from your `PATH`:
   - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
   - [kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md)
   - [kubebuilder](https://kubebuilder.io)
-    - This [Github issue](https://github.com/kubernetes-sigs/controller-runtime/issues/90#issuecomment-494878527)
-      may help you resolve errors you get when running the tests or any other
-      command.
 
 If you're using `gcloud` and the GCP Container Registry, make sure that `gcloud`
 is configured to use the project containing the registry you want to use, and


### PR DESCRIPTION
## What type of PR is this?:
/kind documentation

## What this PR does / why we need it:
These lines are no longer be useful.
So I removed them.

https://github.com/mochizuki875/hierarchical-namespaces/blob/e19ea98273415002c310e9254f7610aec7d62779/docs/contributing.md?plain=1#L56-L58

cf. 
https://github.com/kubernetes-sigs/hierarchical-namespaces/pull/253#discussion_r1102872344
https://github.com/kubernetes-sigs/hierarchical-namespaces/pull/257/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L103-L108

