### PR TITLE
Update Dockerfile to Go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests and all third-party libraries that are unlikely to change frequently


### PR DESCRIPTION
## What this PR does / why we need it:
In #257, Go version has been updated `1.20` from `1.17`.
However the Go version of `Dockerfile` was still `1.17`, so I fixed it.

## Tested:
Unit and E2E tests has passed.