### PR TITLE
Added CLI argument to disable default resource exclusion by label

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,28 +55,29 @@ var (
 )
 
 var (
-	probeAddr               string
-	metricsAddr             string
-	enableStackdriver       bool
-	maxReconciles           int
-	enableLeaderElection    bool
-	leaderElectionId        string
-	noWebhooks              bool
-	debugLogs               bool
-	testLog                 bool
-	internalCert            bool
-	qps                     int
-	webhookServerPort       int
-	restartOnSecretRefresh  bool
-	unpropagatedAnnotations arrayArg
-	excludedNamespaces      arrayArg
-	managedNamespaceLabels  arrayArg
-	managedNamespaceAnnots  arrayArg
-	includedNamespacesRegex string
-	webhooksOnly            bool
-	enableHRQ               bool
-	hncNamespace            string
-	hrqSyncInterval         time.Duration
+	probeAddr                    string
+	metricsAddr                  string
+	enableStackdriver            bool
+	maxReconciles                int
+	enableLeaderElection         bool
+	leaderElectionId             string
+	noWebhooks                   bool
+	debugLogs                    bool
+	testLog                      bool
+	internalCert                 bool
+	qps                          int
+	webhookServerPort            int
+	restartOnSecretRefresh       bool
+	unpropagatedAnnotations      arrayArg
+	excludedNamespaces           arrayArg
+	managedNamespaceLabels       arrayArg
+	managedNamespaceAnnots       arrayArg
+	includedNamespacesRegex      string
+	webhooksOnly                 bool
+	enableHRQ                    bool
+	hncNamespace                 string
+	hrqSyncInterval              time.Duration
+	disableDefaultLabelExclusion bool
 )
 
 // init preloads some global vars before main() starts. Since this is the top-level module, I'm not
@@ -156,10 +157,12 @@ func parseFlags() {
 	flag.BoolVar(&enableHRQ, "enable-hrq", false, "Enables hierarchical resource quotas")
 	flag.StringVar(&hncNamespace, "namespace", "hnc-system", "Namespace where hnc-manager and hnc resources deployed")
 	flag.DurationVar(&hrqSyncInterval, "hrq-sync-interval", 1*time.Minute, "Frequency to double-check that all HRQ usages are up-to-date (shouldn't be needed)")
+	flag.BoolVar(&disableDefaultLabelExclusion, "disable-default-label-exclusion", false, "Disables the default propagation exclusion by label of resources. Currently only Rancher resources are excluded. See the user guide for more information.")
 	flag.Parse()
 
 	// Assign the array args to the configuration variables after the args are parsed.
 	config.UnpropagatedAnnotations = unpropagatedAnnotations
+	config.DisableDefaultLabelExclusion = disableDefaultLabelExclusion
 	config.SetNamespaces(includedNamespacesRegex, excludedNamespaces...)
 	if err := config.SetManagedMeta(managedNamespaceLabels, managedNamespaceAnnots); err != nil {
 		setupLog.Error(err, "Illegal flag values")

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -378,7 +378,9 @@ objects from being propagated by HNC.
   auto-created in new namespaces by Istio and Kubernetes respectively
 * Any objects with the label
   `cattle.io/creator:norman`, which are [inserted by Rancher to support
-  Projects](https://rancher.com/docs/rancher/v2.6/en/system-tools/#remove))
+  Projects](https://rancher.com/docs/rancher/v2.6/en/system-tools/#remove)).
+  This exclusion can be disabled with the `--disable-default-label-exclusion` HNC
+  command-line argument. Refer to the [HNC how-to](how-to.md#admin-cli-args) guide for more details.
 * *HNC v1.1+:* Secrets with type `helm.sh/release.v1`, which is auto-created in
   the namespaces where their respective Helm releases are deployed to.
 

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -956,3 +956,7 @@ Interesting parameters include:
   load on your metrics database (through increased metric cardinality) and also
   by increasing how carefully you need to guard your metrics against
   unauthorized viewers.
+* `--disable-default-label-exclusion`: allows you to disable the exclusion of
+  resources that have pre-defined disallowed labels. Currently only Rancher-generated
+  resources are filtered and excluded from propagation by default. Use this argument
+  to disable this behavior.

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -8,3 +8,4 @@ package config
 // This value is controlled by the --unpropagated-annotation command line, which may be set multiple
 // times.
 var UnpropagatedAnnotations []string
+var DisableDefaultLabelExclusion bool

--- a/internal/selectors/selectors.go
+++ b/internal/selectors/selectors.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	api "sigs.k8s.io/hierarchical-namespaces/api/v1alpha2"
+	"sigs.k8s.io/hierarchical-namespaces/internal/config"
 )
 
 // ShouldPropagate returns true if the given object should be propagated
@@ -246,13 +247,16 @@ func isExcluded(inst *unstructured.Unstructured) (bool, error) {
 	}
 
 	// exclusion by labels
-	for _, res := range exclusionByLabels {
-		gotLabelValue, ok := inst.GetLabels()[res.Key]
-		// check for presence has to be explicit, as empty label values are allowed and a
-		// nonexisting key in the `labels` map will also return an empty string ("") - potentially
-		// causing false matches if `ok` is not checked
-		if ok && gotLabelValue == res.Value {
-			return true, nil
+	// if the default label exclusion is disabled via the manager command line argument, skip it
+	if !config.DisableDefaultLabelExclusion {
+		for _, res := range exclusionByLabels {
+			gotLabelValue, ok := inst.GetLabels()[res.Key]
+			// check for presence has to be explicit, as empty label values are allowed and a
+			// nonexisting key in the `labels` map will also return an empty string ("") - potentially
+			// causing false matches if `ok` is not checked
+			if ok && gotLabelValue == res.Value {
+				return true, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently Rancher-managed resources are skipped and excluded by default without a way to disable this behavior. This PR adds a CLI argument to disable the exclusion.

Ref. https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/104 https://github.com/kubernetes-sigs/hierarchical-namespaces/pull/125 https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/276