### PR TITLE
Changed default excluded labels from hardcoded values to be provided as CLI args, fixed incorrect exclusion bypass with annotation

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,6 +49,9 @@ spec:
         - "--excluded-namespace=kube-public"
         - "--excluded-namespace=hnc-system"
         - "--excluded-namespace=kube-node-lease"
+        # Preserves the existing behavior of skipping Rancher objects.
+        # Please don't add any more nopropagation labels to the list of args.
+        - "--nopropagation-label=cattle.io/creator=norman"
         ports:
         - containerPort: 9443
           name: webhook-server

--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -378,7 +378,10 @@ objects from being propagated by HNC.
   auto-created in new namespaces by Istio and Kubernetes respectively
 * Any objects with the label
   `cattle.io/creator:norman`, which are [inserted by Rancher to support
-  Projects](https://rancher.com/docs/rancher/v2.6/en/system-tools/#remove))
+  Projects](https://rancher.com/docs/rancher/v2.6/en/system-tools/#remove)).
+  Can be disabled by removing the default command line argument on the manager
+  `--nopropagation-label=cattle.io/creator=norman`. Refer to [How-to:
+  Modify command-line arguments](how-to.md#modify-command-line-arguments) for more details.
 * *HNC v1.1+:* Secrets with type `helm.sh/release.v1`, which is auto-created in
   the namespaces where their respective Helm releases are deployed to.
 

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -956,3 +956,12 @@ Interesting parameters include:
   load on your metrics database (through increased metric cardinality) and also
   by increasing how carefully you need to guard your metrics against
   unauthorized viewers.
+* `--nopropagation-label`: has the same effect as the `propagate.hnc.x-k8s.io/none`
+  annotation as specified in [limiting propagation](how-to.md#limit-the-propagation-of-an-object-to-descendant-namespaces),
+  but is useful when there's no control over what annotations the object has in order
+  to disable the propagation of that object. This argument may be specified multiple
+  times, with each parameter representing one `key=val` pair of a label that should
+  exclude an object from propagation.
+    * Rancher objects that have the label `cattle.io/creator=norman` are not propagated
+    by the default manifests (refer to [Concepts: built in exceptions](concepts.md#built-in-exceptions)
+    for more information).

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -8,3 +8,14 @@ package config
 // This value is controlled by the --unpropagated-annotation command line, which may be set multiple
 // times.
 var UnpropagatedAnnotations []string
+
+// NoPropagationLabel specifies a label Key and Value which will cause an object to be excluded
+// from propagation if the object defines that label with this specific value.
+type NoPropagationLabel struct {
+	Key   string
+	Value string
+}
+
+// NoPropagationLabels is a configuration slice that contains all NoPropagationLabel labels that should
+// cause objects to be ignored from propagation.
+var NoPropagationLabels []NoPropagationLabel


### PR DESCRIPTION
As discussed in #276, currently resources which are created by Rancher (and have the `cattle.io/creator=norman` label) are being excluded by default, without any way to disable this behavior. In addition, there a bug that causes resources with the `propagate.hnc.x-k8s.io/all` annotation to be propagated even though they are excluded.

This PR changes the exclude mechanism to rely on a CLI argument to the manager instead of a hardcoded value. It also sets the default arguments of the manager to have the `cattle.io/creator=norman` excluded by default, to keep the same default behavior as before. Documentation is updated to reflect the change. In addition, the bug that caused excluded resources to be propagated when using the `propagate.hnc.x-k8s.io/all` is fixed.

Edit: force-pushed an update that also fixes the bug that was mentioned in the issue.