### PR TITLE
Remove unneeded replace clause from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -122,31 +122,3 @@ require (
 require sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230208013708-22718275bffe
 
 require github.com/spf13/afero v1.6.0 // indirect
-
-replace (
-	k8s.io/api => k8s.io/api v0.23.2
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.23.2
-	k8s.io/apiserver => k8s.io/apiserver v0.23.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.23.2
-	k8s.io/client-go => k8s.io/client-go v0.23.2
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.23.2
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.23.2
-	k8s.io/code-generator => k8s.io/code-generator v0.23.2
-	k8s.io/component-base => k8s.io/component-base v0.23.2
-	k8s.io/component-helpers => k8s.io/component-helpers v0.23.2
-	k8s.io/controller-manager => k8s.io/controller-manager v0.23.2
-	k8s.io/cri-api => k8s.io/cri-api v0.23.2
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.23.2
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.23.2
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.23.2
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.23.2
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.23.2
-	k8s.io/kubectl => k8s.io/kubectl v0.23.2
-	k8s.io/kubelet => k8s.io/kubelet v0.23.2
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.23.2
-	k8s.io/metrics => k8s.io/metrics v0.23.2
-	k8s.io/mount-utils => k8s.io/mount-utils v0.23.2
-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.23.2
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.23.2
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -629,7 +629,7 @@ honnef.co/go/tools/staticcheck/fakereflect
 honnef.co/go/tools/staticcheck/fakexml
 honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
-# k8s.io/api v0.23.2 => k8s.io/api v0.23.2
+# k8s.io/api v0.23.2
 ## explicit; go 1.16
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
@@ -678,7 +678,7 @@ k8s.io/api/scheduling/v1beta1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apiextensions-apiserver v0.23.2 => k8s.io/apiextensions-apiserver v0.23.2
+# k8s.io/apiextensions-apiserver v0.23.2
 ## explicit; go 1.16
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
@@ -687,7 +687,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
-# k8s.io/apimachinery v0.23.2 => k8s.io/apimachinery v0.23.2
+# k8s.io/apimachinery v0.23.2
 ## explicit; go 1.16
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -736,12 +736,12 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/cli-runtime v0.23.2 => k8s.io/cli-runtime v0.23.2
+# k8s.io/cli-runtime v0.23.2
 ## explicit; go 1.16
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
-# k8s.io/client-go v0.23.2 => k8s.io/client-go v0.23.2
+# k8s.io/client-go v0.23.2
 ## explicit; go 1.16
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1beta1
@@ -875,7 +875,7 @@ k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
-# k8s.io/component-base v0.23.2 => k8s.io/component-base v0.23.2
+# k8s.io/component-base v0.23.2
 ## explicit; go 1.16
 k8s.io/component-base/config
 k8s.io/component-base/config/v1alpha1
@@ -1064,28 +1064,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# k8s.io/api => k8s.io/api v0.23.2
-# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.2
-# k8s.io/apimachinery => k8s.io/apimachinery v0.23.2
-# k8s.io/apiserver => k8s.io/apiserver v0.23.2
-# k8s.io/cli-runtime => k8s.io/cli-runtime v0.23.2
-# k8s.io/client-go => k8s.io/client-go v0.23.2
-# k8s.io/cloud-provider => k8s.io/cloud-provider v0.23.2
-# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.23.2
-# k8s.io/code-generator => k8s.io/code-generator v0.23.2
-# k8s.io/component-base => k8s.io/component-base v0.23.2
-# k8s.io/component-helpers => k8s.io/component-helpers v0.23.2
-# k8s.io/controller-manager => k8s.io/controller-manager v0.23.2
-# k8s.io/cri-api => k8s.io/cri-api v0.23.2
-# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.23.2
-# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.23.2
-# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.23.2
-# k8s.io/kube-proxy => k8s.io/kube-proxy v0.23.2
-# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.23.2
-# k8s.io/kubectl => k8s.io/kubectl v0.23.2
-# k8s.io/kubelet => k8s.io/kubelet v0.23.2
-# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.23.2
-# k8s.io/metrics => k8s.io/metrics v0.23.2
-# k8s.io/mount-utils => k8s.io/mount-utils v0.23.2
-# k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.23.2
-# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.23.2


### PR DESCRIPTION
Remove unneeded replace clause from `go.mod`.
It was added as workaround of `k8s.io/kubernetes` import error in #283 .
(ref. https://github.com/kubernetes/kubernetes/issues/79384)

However, `k8s.io/kubernetes` has been removed in #286 as unneeded dependency so replace clause is unneeded too.

related: https://github.com/kubernetes-sigs/hierarchical-namespaces/pull/290#pullrequestreview-1457869921