### PR TITLE
Fix generate HRQ CRD from markers

### DIFF
--- a/api/v1alpha2/hierarchicalresourcequota_types.go
+++ b/api/v1alpha2/hierarchicalresourcequota_types.go
@@ -50,6 +50,7 @@ type HierarchicalResourceQuotaStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=hierarchicalresourcequotas,shortName=hrq,scope=Namespaced
+// +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Request",type="string",JSONPath=".status.requestsSummary"
 // +kubebuilder:printcolumn:name="Limit",type="string",JSONPath=".status.limitsSummary"
 

--- a/config/crd/bases/hnc.x-k8s.io_hierarchicalresourcequotas.yaml
+++ b/config/crd/bases/hnc.x-k8s.io_hierarchicalresourcequotas.yaml
@@ -91,3 +91,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}


### PR DESCRIPTION
While working on https://github.com/kubernetes-sigs/hierarchical-namespaces/pull/285, I noticed that running `make manifests` updates the HRQ CRD. This also happens on the master branch, which I think is not intentional and wrong. This PR fixes this by regenerating the HRQ CRD.

The PR also marks the current HRQ as the storage version - which I discovered as missing when comparing the kubebuilder markers for the CRDs.

I think the difference is caused by a minor bug in `controller-gen`, and is related to the recently added print columns on HRQ. The columns include fields from the HRQ **status**, and I think there is some code in controller-gen assuming the CRD has a status subresource when including fields from status as print columns.

I really think we should have status as subresources - especially on HRQ, but I don't have the bandwidth to fix that.

/cc @adrianludwin 