### PR TITLE
docs: fix typos in Concepts and FAQ

### DIFF
--- a/docs/user-guide/concepts.md
+++ b/docs/user-guide/concepts.md
@@ -232,8 +232,8 @@ You can create a subnamespace from the command line via `kubectl hns create chil
 When you want to give some amount of resources to `team-a`, and want them to be able to
 flexibly use resources in any of their subnamespaces, you create a `HierarchicalResourceQuota`
 in namespace `team-a`. The sum of all resources from all the subnamespaces of the
-members wont be over the amount of resources that is configured in
-`HierarchicalResourceQuota` of namespace `team-a`. All of the reasources of `team-a` are
+members won't be over the amount of resources that is configured in
+`HierarchicalResourceQuota` of namespace `team-a`. All of the resources of `team-a` are
 equally shared between the applications in their subnamespaces, which is very efficient.
 
 In addition, you can let an org or team's admin create their own hierarchical
@@ -251,7 +251,7 @@ company-a
 │   ...
 ...
 ```
-Instead of each team asking from the `cluster-admin` to modify their `ResourceQuota`, 
+Instead of each team asking from the `cluster-admin` to modify their `ResourceQuota`,
 you can insert an additional "policy" namespace above each level to hold
 the policy objects (like hierarchical quota) that the sub-admin _cannot_
 change, while giving them permission to create their own quotas in the

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -47,7 +47,7 @@ for any sane use case.
 ## How does HNC scale?
 
 HNC is deployed as a single pod with in-memory state, so it cannot scale
-horizontally. In practice, we have found the the API throttling by the K8s
+horizontally. In practice, we have found the API throttling by the K8s
 apiserver is by far the greatest bottleneck on HNC performance, which would not
 be improved via horizontal scaling. Almost all validating webhook calls are also
 served entirely by in-memory state and as a result should be extremely fast.


### PR DESCRIPTION
## Summary

Fixes a few typos in the docs that I stumbled upon

## Details

- "the the" -> "the"
- "wont" -> "won't"
- "reasources" -> "resources"