### PR TITLE
docs: improve grammar and simplify HRQ examples 

### DIFF
--- a/docs/user-guide/quickstart.md
+++ b/docs/user-guide/quickstart.md
@@ -461,11 +461,11 @@ kubectl delete pods s2 -n service-2
 
 <a name="hrq"/>
 
-### Hierarchical resource quotas
+### Hierarchical resource quotas (HRQs)
 
 ***Hierarchical resource quotas are beta in HNC v1.1***
 
-***HRQs are not included by default, to use it install the hrq.yaml file in the [releases -> Assets](https://github.com/kubernetes-sigs/hierarchical-namespaces/releases)***
+***HRQs are not included by default. To use it, install the `hrq.yaml` file in [Releases -> Assets](https://github.com/kubernetes-sigs/hierarchical-namespaces/releases)***
 
 _Will demonstrate: Create and delete [HierarchicalResourceQuota](concepts.md#hierarchical-resource-quota)._
 
@@ -476,11 +476,11 @@ acme-org
 └── [s] team-b
 ```
 
-You can create a `HierarchicalResourceQuota` in namespace `acme-org`, and the sum of 
-all subnamespaces resource usage can't go over what is configured in the HRQ.
+If you create a `HierarchicalResourceQuota` in namespace `acme-org`, the sum of
+all subnamespaces' resources can't surpass the HRQ.
 
 We will demonstrate how it works using services, but you could also limit `cpu`,
-`memory` or any other `ResourceQuota` field.
+`memory`, or any other `ResourceQuota` field.
 
 Creating the HRQ:
 ```bash
@@ -525,12 +525,12 @@ acme-org   services: 1/1
 ```
 You can also view HRQs in all namespaces by running `kubectl get hrq -A`.
 
-And finally you can delete the HRQ via simply deleting the CR:
+And finally, you can delete the HRQ by deleting the CR:
 ```bash
 kubectl delete hrq acme-org-hrq -n acme-org
 ```
 
-Note: Decimal point values cannot be specified (you can't do `cpu: 1.5` but
+Note: Decimal point values cannot be specified (you can't do `cpu: 1.5`, but
 you can do `cpu: "1.5"` or `cpu: 1500m`). See [#292](https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/292)
 
 <a name="subns"/>


### PR DESCRIPTION
## Summary

Was reading through the docs and these seemed the most verbose
- it seems to be a very recent feature as well, from #289

## Details

- use same heading in both Quickstart and Concepts, including HRQ abbreviation
  - use abbreviation to shorten the HRQ docs themselves as well

### Grammar

- fix run-on sentences by adding punctuation
  - "by default, to use it" -> "by default. To use it"
  - and a few others
- add missing commas
  - "Then,", "finally,", etc
- add Oxford commas
  - ", but", ", and", ", or", etc

### Simplifications

- simplify several sentences, per [k8s style guide](https://kubernetes.io/docs/contribute/style/style-guide/#use-simple-and-direct-language)
  - "won't be over the amount of resources that is configured in `HierarchicalResourceQuota`" -> "cannot surpass the HRQ"
    - "can't go over what is configured in the HRQ" -> "can't surpass the HRQ"
  - "And put the resources HRQ in" -> "An HRQ in"
    - "This will restrict whole" -> "restricts" (also uses present tense now, per style guide)
  - "the amount of resources that" -> "the resources"
    - "resource usage" -> "resources"
  - "automatically creates" -> "creates"

- in a similar vein, remove or replace ambiguous language
  - "equally shared" -> "shared" -- they can be shared however, not necessarily "equally"
  - "which is very efficient" -> "" -- "efficient" could be interpreted in a performance sense and is unnecesary
  - "lower level", "level" -> "child" / "sub" -- use HNC's existing terminology instead of "lower level", which has multiple disambiguations
    - Similarly use HNC's existing terminology for:
      - "individual", "members" -> "namespace", "subnamespaces"
      - "above", "overall" -> "parent"
  - "wins" -> "applies" -- replace idiom, per [style guide](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-jargon-and-idioms)
  - also remove the word "simply", per [style guide](https://kubernetes.io/docs/contribute/style/style-guide/#avoid-words-that-assume-a-specific-level-of-understanding)

- clarify a few sentences with a single word
  - "within", "Instead", "still", "directly"

- consolidate the two paragraphs on command-line usage into one
  - looks like they were added at different times, in #298
  - they largely duplicated each other with slightly different wording
  - creating an HRQ via a CR YAML is the definition of how CRs work, which are already used across HNC, so not necessary to re-explain

## Review Notes

There are potentially more changes that could be made according to the style guide, but I primarily focused changes on simplifications, clarifications, and grammar
- **EDIT**: See #316 as one follow-up

## Misc

This is a great example! It gives very practical, real-world use-cases which is very helpful for context and understanding how one might use HNC!