### PR TITLE
Support unpropagated labels

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -70,6 +70,7 @@ var (
 	webhookServerPort       int
 	restartOnSecretRefresh  bool
 	unpropagatedAnnotations arrayArg
+	unpropagatedLabels      arrayArg
 	excludedNamespaces      arrayArg
 	managedNamespaceLabels  arrayArg
 	managedNamespaceAnnots  arrayArg
@@ -148,6 +149,7 @@ func parseFlags() {
 	flag.IntVar(&qps, "apiserver-qps-throttle", 50, "The maximum QPS to the API server. See the user guide for more information.")
 	flag.BoolVar(&stats.SuppressObjectTags, "suppress-object-tags", true, "If true, suppresses the kinds of object metrics to reduce metric cardinality. See the user guide for more information.")
 	flag.IntVar(&webhookServerPort, "webhook-server-port", 443, "The port that the webhook server serves at.")
+	flag.Var(&unpropagatedLabels, "unpropagated-label", "An label that, if present, will be stripped out of any propagated copies of an object. May be specified multiple times, with each instance specifying one label. See the user guide for more information.")
 	flag.Var(&unpropagatedAnnotations, "unpropagated-annotation", "An annotation that, if present, will be stripped out of any propagated copies of an object. May be specified multiple times, with each instance specifying one annotation. See the user guide for more information.")
 	flag.Var(&excludedNamespaces, "excluded-namespace", "A namespace that, if present, will be excluded from HNC management. May be specified multiple times, with each instance specifying one namespace. See the user guide for more information.")
 	flag.StringVar(&includedNamespacesRegex, "included-namespace-regex", ".*", "Namespace regular expression. Namespaces that match this regexp will be included and handle by HNC. The regex is implicitly wrapped by \"^...$\" and may only be specified once.")
@@ -163,6 +165,7 @@ func parseFlags() {
 
 	// Assign the array args to the configuration variables after the args are parsed.
 	config.UnpropagatedAnnotations = unpropagatedAnnotations
+	config.UnpropagatedLabels = unpropagatedLabels
 
 	// Assign the exclusion label args to the configuration
 	for _, label := range nopropagationLabel {

--- a/config/crd/bases/hnc.x-k8s.io_hierarchicalresourcequotas.yaml
+++ b/config/crd/bases/hnc.x-k8s.io_hierarchicalresourcequotas.yaml
@@ -91,3 +91,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -951,6 +951,14 @@ Interesting parameters include:
   used to remove an annotation on the source object that's has a special meaning
   to another system, such as GKE Config Sync. If you restart HNC after changing
   this arg, all _existing_ propagated objects will also be updated.
+* `--unpropagated-label=<string>`: empty by default, this argument
+  can be specified multiple times, with each parameter representing an
+  label name, such as `example.com/foo`. When HNC propagates objects from
+  ancestor to descendant namespaces, it will strip these labels out of the
+  metadata of the _copy_ of the object, if it exists. For example, this can be
+  used to remove an label on the source object that's has a special meaning
+  to another system, such as ArgoCD. If you restart HNC after changing
+  this arg, all _existing_ propagated objects will also be updated.
 * `--apiserver-qps-throttle=<integer>`: set to 50 by default, this limits how many
   requests HNC will send to the Kubernetes apiserver per second in the steady
   state (it may briefly allow up to 50% more than this number). Setting this

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -9,6 +9,15 @@ package config
 // times.
 var UnpropagatedAnnotations []string
 
+// UnpropgatedLabels is a list of labels on objects that should _not_ be propagated by HNC.
+// Much like HNC itself, other systems (such as ArgoCD) use labels to "claim" an
+// object - such as deleting objects it doesn't recognize. By removing these labels on
+// propgated objects, HNC ensures that other systems won't attempt to claim the same object.
+//
+// This value is controlled by the --unpropagated-label command line, which may be set multiple
+// times.
+var UnpropagatedLabels []string
+
 // NoPropagationLabel specifies a label Key and Value which will cause an object to be excluded
 // from propagation if the object defines that label with this specific value.
 type NoPropagationLabel struct {

--- a/internal/objects/reconciler.go
+++ b/internal/objects/reconciler.go
@@ -503,6 +503,11 @@ func cleanSource(src *unstructured.Unstructured) *unstructured.Unstructured {
 		labels = map[string]string{}
 	}
 	labels[api.LabelManagedByApps] = api.MetaGroup
+
+	// Clean out bad labels.
+	for _, unprop := range config.UnpropagatedLabels {
+		delete(labels, unprop)
+	}
 	src.SetLabels(labels)
 
 	return src


### PR DESCRIPTION
By default ArgoCD use labels to understand which objects it controls.

When HNC propagates those resources ArgoCD assumes ownership of those
resources and attempts to reconcile it with current state, usually
leading to deletion of those resources.
This causes a feedback loop where ArgoCD requests a deletion of an
object, that is blocked by the HNC webhook, and HNC no longer is able to
properly manage the resource due to the deletion finaliser set on the
resource.

This is similar behaviour to ConfigSync with annotations.

This commit adds an unpropagated-labels command line argument following the
implementation of the unpropagated-annotations argument. This allows
cluster operators to disable propagation of labels owned by systems like
ArgoCD.

Tested:
* Implemented additional e2e test matching unpropagated-annotations tests.
* Manually validated that configured labels were not propogated as expected
  and ArgoCD did not adopt propgated resources.
