### PR TITLE
CGO_ENABLED=0 in building linux binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-only: build-setup-envtest
 # Builds all binaries (manager and kubectl) and manifests
 build: generate fmt vet staticcheck manifests
 	go build -o bin/manager ./cmd/manager/main.go
-	GOOS=linux GOARCH=amd64 go build \
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 	     -o bin/kubectl/kubectl-hns_linux_amd64 \
 	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
 	     ./cmd/kubectl/main.go
@@ -125,11 +125,11 @@ build: generate fmt vet staticcheck manifests
 	     -o bin/kubectl/kubectl-hns_darwin_arm64 \
 	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
 	     ./cmd/kubectl/main.go
-	GOOS=linux GOARCH=arm64 go build \
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build \
 	     -o bin/kubectl/kubectl-hns_linux_arm64 \
 	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
 	     ./cmd/kubectl/main.go
-	GOOS=linux GOARCH=arm go build \
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build \
 	     -o bin/kubectl/kubectl-hns_linux_arm \
 	     -ldflags="-X sigs.k8s.io/hierarchical-namespaces/internal/version.Version=${HNC_IMG_TAG}" \
 	     ./cmd/kubectl/main.go


### PR DESCRIPTION
The current binary is dynamic-executable.
```
$ ldd kubectl-hns_linux_amd64 
	linux-vdso.so.1 (0x00007ffc3034b000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f608e2d7000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f608e50e000)
```
This is unavoidable for MacOS and Windows, but since Linux environments are required to operate under the minimum necessary conditions, I think we should make not a dynamic executable but a single-binary.
The concern is that the size will increase, but it is smaller than the original binary (62.2 MB -> **47 MB**)
```
$ ls -hl bin/kubectl/kubectl-hns_linux_amd64
-rwxr-xr-x  1   staff    47M 11 14 17:04 bin/kubectl/kubectl-hns_linux_amd64*
```