### PR TITLE
Add default for the --namespace when it is not specify.

### DIFF
--- a/internal/kubectl/create.go
+++ b/internal/kubectl/create.go
@@ -37,7 +37,7 @@ var createCmd = &cobra.Command{
 	},
 }
 
-func newCreateCmd() *cobra.Command {
-	createCmd.Flags().StringP("namespace", "n", "", "The parent namespace for the new subnamespace")
+func newCreateCmd(defaultNs string) *cobra.Command {
+	createCmd.Flags().StringVarP(&namespace, "namespace", "n", defaultNs, "The parent namespace for the new subnamespace")
 	return createCmd
 }

--- a/internal/kubectl/delete.go
+++ b/internal/kubectl/delete.go
@@ -56,8 +56,8 @@ var deleteCmd = &cobra.Command{
 	},
 }
 
-func newDeleteCmd() *cobra.Command {
-	deleteCmd.Flags().StringP("namespace", "n", "", "The parent namespace for the new subnamespace")
+func newDeleteCmd(defaultNs string) *cobra.Command {
+	deleteCmd.Flags().StringVarP(&namespace, "namespace", "n", defaultNs, "The parent namespace for the new subnamespace")
 	deleteCmd.Flags().BoolP("allowCascadingDeletion", "a", false, "Allows cascading deletion of its subnamespaces.")
 	return deleteCmd
 }

--- a/internal/kubectl/root.go
+++ b/internal/kubectl/root.go
@@ -62,6 +62,10 @@ func init() {
 	client = &realClient{}
 
 	kubecfgFlags := genericclioptions.NewConfigFlags(false)
+	defaultNs, _, err := kubecfgFlags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		fmt.Printf("Error reading namespace in default kubeconfig :%s\n", err.Error())
+	}
 
 	rootCmd = &cobra.Command{
 		// We should use "kubectl hns" instead of "kubectl-hns" to invoke the plugin.
@@ -102,8 +106,8 @@ func init() {
 	rootCmd.AddCommand(newSetCmd())
 	rootCmd.AddCommand(newDescribeCmd())
 	rootCmd.AddCommand(newTreeCmd())
-	rootCmd.AddCommand(newCreateCmd())
-	rootCmd.AddCommand(newDeleteCmd())
+	rootCmd.AddCommand(newCreateCmd(defaultNs))
+	rootCmd.AddCommand(newDeleteCmd(defaultNs))
 	rootCmd.AddCommand(newConfigCmd())
 	rootCmd.AddCommand(newVersionCmd())
 	rootCmd.AddCommand(newHrqCmd())


### PR DESCRIPTION
Fixes [issue 347](https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/347).
Add default for the --namespace when it is not specify.

Before is:
![image](https://github.com/kubernetes-sigs/hierarchical-namespaces/assets/12080746/979eaa0e-f5f8-474a-a1eb-3ffc95caa4c9)


After update :
<img width="1012" alt="image" src="https://github.com/kubernetes-sigs/hierarchical-namespaces/assets/12080746/b183269e-ccfd-48ab-9fb4-423ccdce7cc9">

