### PR TITLE
Use GVK to validate resource type

### DIFF
--- a/internal/hncconfig/reconciler.go
+++ b/internal/hncconfig/reconciler.go
@@ -148,10 +148,20 @@ func (r *Reconciler) reconcileConfigTypes(inst *api.HNCConfiguration) {
 	// Get valid settings in the spec.resources of the `config` singleton.
 	for _, rsc := range inst.Spec.Resources {
 		gr := schema.GroupResource{Group: rsc.Group, Resource: rsc.Resource}
-		// If there are multiple configurations of the same type, we will follow the
+		// Look if the resource exists in the API server.
+		gvk, err := r.resourceMapper.NamespacedKindFor(gr)
+		if err != nil {
+			// Log error and write conditions, but don't early exit since the other types can still be reconciled.
+			r.Log.Error(err, "while trying to reconcile the configuration", "type", gr, "mode", rsc.Mode)
+			r.writeCondition(inst, api.ConditionBadTypeConfiguration, reasonForGVKError(err), err.Error())
+			continue
+		}
+
+		// If there are multiple configurations of the same GVK, we will follow the
 		// first configuration and ignore the rest.
-		if gvkMode, exist := r.activeGVKMode[gr]; exist {
-			log := r.Log.WithValues("resource", gr, "appliedMode", gvkMode.mode)
+		if firstGR, exist := r.activeGR[gvk]; exist {
+			gvkMode := r.activeGVKMode[firstGR]
+			log := r.Log.WithValues("resource", gr, "appliedMode", rsc.Mode)
 			msg := ""
 			// Set a different message if the type is enforced by HNC.
 			if api.IsEnforcedType(rsc) {
@@ -165,14 +175,6 @@ func (r *Reconciler) reconcileConfigTypes(inst *api.HNCConfiguration) {
 			continue
 		}
 
-		// Look if the resource exists in the API server.
-		gvk, err := r.resourceMapper.NamespacedKindFor(gr)
-		if err != nil {
-			// Log error and write conditions, but don't early exit since the other types can still be reconciled.
-			r.Log.Error(err, "while trying to reconcile the configuration", "type", gr, "mode", rsc.Mode)
-			r.writeCondition(inst, api.ConditionBadTypeConfiguration, reasonForGVKError(err), err.Error())
-			continue
-		}
 		r.activeGVKMode[gr] = gvkMode{gvk, rsc.Mode}
 		r.activeGR[gvk] = gr
 	}

--- a/internal/hncconfig/reconciler_test.go
+++ b/internal/hncconfig/reconciler_test.go
@@ -89,6 +89,22 @@ var _ = Describe("HNCConfiguration", func() {
 		Eventually(GetHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).Should(ContainSubstring(api.RoleResource))
 	})
 
+	It("should ignore the `roles` configuration in the spec and set `MultipleConfigurationsForType` condition even when given in a singular form", func() {
+		AddToHNCConfig(ctx, api.RBACGroup, "role", api.Ignore)
+
+		Eventually(typeSpecMode(ctx, api.RBACGroup, "role")).Should(Equal(api.Ignore))
+		Eventually(typeStatusMode(ctx, api.RBACGroup, api.RoleResource)).Should(Equal(api.Propagate))
+		Eventually(GetHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).Should(ContainSubstring("role"))
+	})
+
+	It("should ignore the `roles` configuration in the spec and set `MultipleConfigurationsForType` condition even when specified without group", func() {
+		AddToHNCConfig(ctx, "", api.RoleResource, api.Ignore)
+
+		Eventually(typeSpecMode(ctx, "", api.RoleResource)).Should(Equal(api.Ignore))
+		Eventually(typeStatusMode(ctx, api.RBACGroup, api.RoleResource)).Should(Equal(api.Propagate))
+		Eventually(GetHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).Should(ContainSubstring(api.RoleResource))
+	})
+
 	It("should propagate RoleBindings by default", func() {
 		SetParent(ctx, barName, fooName)
 		// Give foo a role binding.
@@ -102,6 +118,22 @@ var _ = Describe("HNCConfiguration", func() {
 		AddToHNCConfig(ctx, api.RBACGroup, api.RoleBindingResource, api.Ignore)
 
 		Eventually(typeSpecMode(ctx, api.RBACGroup, api.RoleBindingResource)).Should(Equal(api.Ignore))
+		Eventually(typeStatusMode(ctx, api.RBACGroup, api.RoleBindingResource)).Should(Equal(api.Propagate))
+		Eventually(GetHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).Should(ContainSubstring(api.RoleBindingResource))
+	})
+
+	It("should ignore the `rolebindings` configuration in the spec and set `MultipleConfigurationsForType` condition even when given in a singular form", func() {
+		AddToHNCConfig(ctx, api.RBACGroup, "rolebinding", api.Ignore)
+
+		Eventually(typeSpecMode(ctx, api.RBACGroup, "rolebinding")).Should(Equal(api.Ignore))
+		Eventually(typeStatusMode(ctx, api.RBACGroup, api.RoleBindingResource)).Should(Equal(api.Propagate))
+		Eventually(GetHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).Should(ContainSubstring("rolebinding"))
+	})
+
+	It("should ignore the `rolebindings` configuration in the spec and set `MultipleConfigurationsForType` condition even when specified without group", func() {
+		AddToHNCConfig(ctx, "", api.RoleBindingResource, api.Ignore)
+
+		Eventually(typeSpecMode(ctx, "", api.RoleBindingResource)).Should(Equal(api.Ignore))
 		Eventually(typeStatusMode(ctx, api.RBACGroup, api.RoleBindingResource)).Should(Equal(api.Propagate))
 		Eventually(GetHNCConfigCondition(ctx, api.ConditionBadTypeConfiguration, api.ReasonMultipleConfigsForType)).Should(ContainSubstring(api.RoleBindingResource))
 	})

--- a/internal/hncconfig/validator_test.go
+++ b/internal/hncconfig/validator_test.go
@@ -24,6 +24,10 @@ var (
 	gr2gvk = map[schema.GroupResource]schema.GroupVersionKind{
 		{Group: api.RBACGroup, Resource: api.RoleResource}:        {Group: api.RBACGroup, Version: "v1", Kind: api.RoleKind},
 		{Group: api.RBACGroup, Resource: api.RoleBindingResource}: {Group: api.RBACGroup, Version: "v1", Kind: api.RoleBindingKind},
+		{Group: api.RBACGroup, Resource: "role"}:                  {Group: api.RBACGroup, Version: "v1", Kind: api.RoleKind},
+		{Group: api.RBACGroup, Resource: "rolebinding"}:           {Group: api.RBACGroup, Version: "v1", Kind: api.RoleBindingKind},
+		{Resource: api.RoleResource}:                              {Group: api.RBACGroup, Version: "v1", Kind: api.RoleKind},
+		{Resource: api.RoleBindingResource}:                       {Group: api.RBACGroup, Version: "v1", Kind: api.RoleBindingKind},
 		{Group: "", Resource: "secrets"}:                          {Group: "", Version: "v1", Kind: "Secret"},
 		{Group: "", Resource: "resourcequotas"}:                   {Group: "", Version: "v1", Kind: "ResourceQuota"},
 	}
@@ -84,6 +88,22 @@ func TestRBACTypes(t *testing.T) {
 			configs: []api.ResourceSpec{
 				{Group: api.RBACGroup, Resource: api.RoleResource, Mode: api.Propagate},
 				{Group: api.RBACGroup, Resource: api.RoleBindingResource, Mode: api.Propagate},
+			},
+			allow: false,
+		},
+		{
+			name: "Configure redundant enforced resources in a singular manner",
+			configs: []api.ResourceSpec{
+				{Group: api.RBACGroup, Resource: "role", Mode: api.AllowPropagate},
+				{Group: api.RBACGroup, Resource: "rolebinding", Mode: api.AllowPropagate},
+			},
+			allow: false,
+		},
+		{
+			name: "Configure redundant enforced resources without specifying group",
+			configs: []api.ResourceSpec{
+				{Resource: api.RoleResource, Mode: api.AllowPropagate},
+				{Resource: api.RoleBindingResource, Mode: api.AllowPropagate},
 			},
 			allow: false,
 		},


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/343

### Promlem
It is enforced to set Role and RoleBinding as 'Propagate' mode in the HNCConfiguration, but the validation is not enough. It is validated using GRs(GroupResources) user specified in the `spec.resources` field. GR includes some ambiguity and users can specify resources in several way (e.g. use empty group instead of "v1", use singular instead of plural). They are not picked up by the current isEnforcedType matcher and as a result they are registered to the activeGVKs even though duplicated. It causes the flapping between the enforced 'Propagate' state and the user given state like 'AllowPropagate' in the reconciliation phase as follows:

```
{"level":"info","ts":"2024-01-08T01:14:05Z","logger":"hncconfig.reconcile","msg":"Changing sync mode of the object reconciler","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding","oldMode":"AllowPropagate","newMode":"Propagate"}
{"level":"info","ts":"2024-01-08T01:14:05Z","logger":"hncconfig.reconcile","msg":"Changing sync mode of the object reconciler","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding","oldMode":"Propagate","newMode":"AllowPropagate"}
{"level":"info","ts":"2024-01-08T01:14:05Z","logger":"hncconfig.reconcile","msg":"Changing sync mode of the object reconciler","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding","oldMode":"AllowPropagate","newMode":"Propagate"}
{"level":"info","ts":"2024-01-08T01:14:05Z","logger":"hncconfig.reconcile","msg":"Changing sync mode of the object reconciler","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding","oldMode":"Propagate","newMode":"AllowPropagate"}
{"level":"info","ts":"2024-01-08T01:14:05Z","logger":"hncconfig.reconcile","msg":"Changing sync mode of the object reconciler","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding","oldMode":"AllowPropagate","newMode":"Propagate"}
{"level":"info","ts":"2024-01-08T01:14:05Z","logger":"hncconfig.reconcile","msg":"Changing sync mode of the object reconciler","gvk":"rbac.authorization.k8s.io/v1, Kind=RoleBinding","oldMode":"Propagate","newMode":"AllowPropagate"}
...
```

### How to address
Use GVK instead of GR to check whether enforcedType or not on both webhook validator and reconcilier.