### PR TITLE
Helm Chart for HNC installation

### DIFF
--- a/charts/hnc/.helmignore
+++ b/charts/hnc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/hnc/Chart.yaml
+++ b/charts/hnc/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: hnc
+description: A Helm chart to install hnc on Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.1.0"

--- a/charts/hnc/crds/hierarchicalresourcequotas.hnc.x-k8s.io.yaml
+++ b/charts/hnc/crds/hierarchicalresourcequotas.hnc.x-k8s.io.yaml
@@ -1,0 +1,82 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.4
+  name: hierarchicalresourcequotas.hnc.x-k8s.io
+spec:
+  group: hnc.x-k8s.io
+  names:
+    kind: HierarchicalResourceQuota
+    listKind: HierarchicalResourceQuotaList
+    plural: hierarchicalresourcequotas
+    shortNames:
+      - hrq
+    singular: hierarchicalresourcequota
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.requestsSummary
+          name: Request
+          type: string
+        - jsonPath: .status.limitsSummary
+          name: Limit
+          type: string
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: HierarchicalResourceQuota sets aggregate quota restrictions enforced for a namespace and descendant namespaces
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired quota
+              properties:
+                hard:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Hard is the set of desired hard limits for each named resource
+                  type: object
+              type: object
+            status:
+              description: Status defines the actual enforced quota and its current usage
+              properties:
+                hard:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Hard is the set of enforced hard limits for each named resource
+                  type: object
+                limitsSummary:
+                  description: LimitsSummary is used by kubectl get hrq, and summarizes the relevant information from .status.hard.limits and .status.used.limits.
+                  type: string
+                requestsSummary:
+                  description: RequestsSummary is used by kubectl get hrq, and summarizes the relevant information from .status.hard.requests and .status.used.requests.
+                  type: string
+                used:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Used is the current observed total usage of the resource in the namespace and its descendant namespaces.
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/charts/hnc/crds/hierarchyconfigurations.hnc.x-k8s.io.yaml
+++ b/charts/hnc/crds/hierarchyconfigurations.hnc.x-k8s.io.yaml
@@ -1,0 +1,131 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.4
+  name: hierarchyconfigurations.hnc.x-k8s.io
+spec:
+  group: hnc.x-k8s.io
+  names:
+    kind: HierarchyConfiguration
+    listKind: HierarchyConfigurationList
+    plural: hierarchyconfigurations
+    singular: hierarchyconfiguration
+  scope: Namespaced
+  versions:
+    - name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: Hierarchy is the Schema for the hierarchies API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              properties:
+                name:
+                  enum:
+                    - hierarchy
+                  type: string
+              type: object
+            spec:
+              description: HierarchySpec defines the desired state of Hierarchy
+              properties:
+                allowCascadingDeletion:
+                  description: AllowCascadingDeletion indicates if the subnamespaces of this namespace are allowed to cascading delete.
+                  type: boolean
+                annotations:
+                  description: Annotations is a list of annotations and values to apply to the current namespace and all of its descendants. All annotation keys must match a regex specified on the command line by --managed-namespace-annotation. A namespace cannot have a KVP that conflicts with one of its ancestors.
+                  items:
+                    description: MetaKVP represents a label or annotation
+                    properties:
+                      key:
+                        description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                        type: string
+                      value:
+                        description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                        type: string
+                    required:
+                      - key
+                      - value
+                    type: object
+                  type: array
+                labels:
+                  description: Lables is a list of labels and values to apply to the current namespace and all of its descendants. All label keys must match a regex specified on the command line by --managed-namespace-label. A namespace cannot have a KVP that conflicts with one of its ancestors.
+                  items:
+                    description: MetaKVP represents a label or annotation
+                    properties:
+                      key:
+                        description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                        type: string
+                      value:
+                        description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                        type: string
+                    required:
+                      - key
+                      - value
+                    type: object
+                  type: array
+                parent:
+                  description: Parent indicates the parent of this namespace, if any.
+                  type: string
+              type: object
+            status:
+              description: HierarchyStatus defines the observed state of Hierarchy
+              properties:
+                children:
+                  description: Children indicates the direct children of this namespace, if any.
+                  items:
+                    type: string
+                  type: array
+                conditions:
+                  description: Conditions describes the errors, if any.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/charts/hnc/crds/hncconfigurations.hnc.x-k8s.io.yaml
+++ b/charts/hnc/crds/hncconfigurations.hnc.x-k8s.io.yaml
@@ -1,0 +1,142 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.4
+  name: hncconfigurations.hnc.x-k8s.io
+spec:
+  group: hnc.x-k8s.io
+  names:
+    kind: HNCConfiguration
+    listKind: HNCConfigurationList
+    plural: hncconfigurations
+    singular: hncconfiguration
+  scope: Cluster
+  versions:
+    - name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: HNCConfiguration is a cluster-wide configuration for HNC as a whole. See details in http://bit.ly/hnc-type-configuration
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              properties:
+                name:
+                  enum:
+                    - config
+                  type: string
+              type: object
+            spec:
+              description: HNCConfigurationSpec defines the desired state of HNC configuration.
+              properties:
+                resources:
+                  description: Resources defines the cluster-wide settings for resource synchronization. Note that 'roles' and 'rolebindings' are pre-configured by HNC with 'Propagate' mode and are omitted in the spec. Any configuration of 'roles' or 'rolebindings' are not allowed. To learn more, see https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#admin-types
+                  items:
+                    description: ResourceSpec defines the desired synchronization state of a specific resource.
+                    properties:
+                      group:
+                        description: Group of the resource defined below. This is used to unambiguously identify the resource. It may be omitted for core resources (e.g. "secrets").
+                        type: string
+                      mode:
+                        description: Synchronization mode of the kind. If the field is empty, it will be treated as "Propagate".
+                        enum:
+                          - Propagate
+                          - Ignore
+                          - Remove
+                          - AllowPropagate
+                        type: string
+                      resource:
+                        description: Resource to be configured.
+                        type: string
+                    required:
+                      - resource
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: HNCConfigurationStatus defines the observed state of HNC configuration.
+              properties:
+                conditions:
+                  description: Conditions describes the errors, if any. If there are any conditions with "ActivitiesHalted" reason, this means that HNC cannot function in the affected namespaces. The HierarchyConfiguration object in each of the affected namespaces will have more information. To learn more about conditions, see https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/concepts.md#admin-conditions.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                resources:
+                  description: Resources indicates the observed synchronization states of the resources.
+                  items:
+                    description: ResourceStatus defines the actual synchronization state of a specific resource.
+                    properties:
+                      group:
+                        description: The API group of the resource being synchronized.
+                        type: string
+                      mode:
+                        description: Mode describes the synchronization mode of the kind. Typically, it will be the same as the mode in the spec, except when the reconciler has fallen behind or for resources with an enforced default synchronization mode, such as RBAC objects.
+                        type: string
+                      numPropagatedObjects:
+                        description: Tracks the number of objects that are being propagated to descendant namespaces. The propagated objects are created by HNC.
+                        minimum: 0
+                        type: integer
+                      numSourceObjects:
+                        description: Tracks the number of objects that are created by users.
+                        minimum: 0
+                        type: integer
+                      resource:
+                        description: The resource being synchronized.
+                        type: string
+                      version:
+                        description: The API version used by HNC when propagating this resource.
+                        type: string
+                    required:
+                      - group
+                      - resource
+                      - version
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/charts/hnc/crds/subnamespaceanchors.hnc.x-k8s.io.yaml
+++ b/charts/hnc/crds/subnamespaceanchors.hnc.x-k8s.io.yaml
@@ -1,0 +1,75 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.4
+  name: subnamespaceanchors.hnc.x-k8s.io
+spec:
+  group: hnc.x-k8s.io
+  names:
+    kind: SubnamespaceAnchor
+    listKind: SubnamespaceAnchorList
+    plural: subnamespaceanchors
+    shortNames:
+      - subns
+    singular: subnamespaceanchor
+  scope: Namespaced
+  versions:
+    - name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: SubnamespaceAnchor is the Schema for the subnamespace API. See details at http://bit.ly/hnc-self-serve-ux.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                annotations:
+                  description: Annotations is a list of annotations and values to apply to the current subnamespace and all of its descendants. All annotation keys must match a regex specified on the command line by --managed-namespace-annotation. All annotation keys must be managed annotations (see HNC docs) and must match a regex
+                  items:
+                    description: MetaKVP represents a label or annotation
+                    properties:
+                      key:
+                        description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                        type: string
+                      value:
+                        description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                        type: string
+                    required:
+                      - key
+                      - value
+                    type: object
+                  type: array
+                labels:
+                  description: Labels is a list of labels and values to apply to the current subnamespace and all of its descendants. All label keys must match a regex specified on the command line by --managed-namespace-label. All label keys must be managed labels (see HNC docs) and must match a regex
+                  items:
+                    description: MetaKVP represents a label or annotation
+                    properties:
+                      key:
+                        description: Key is the name of the label or annotation. It must conform to the normal rules for Kubernetes label/annotation keys.
+                        type: string
+                      value:
+                        description: Value is the value of the label or annotation. It must confirm to the normal rules for Kubernetes label or annoation values, which are far more restrictive for labels than for anntations.
+                        type: string
+                    required:
+                      - key
+                      - value
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: SubnamespaceAnchorStatus defines the observed state of SubnamespaceAnchor.
+              properties:
+                status:
+                  description: "Describes the state of the subnamespace anchor. \n Currently, the supported values are: \n - \"Missing\": the subnamespace has not been created yet. This should be the default state when the anchor is just created. \n - \"Ok\": the subnamespace exists. This is the only good state of the anchor. \n - \"Conflict\": a namespace of the same name already exists. The admission controller will attempt to prevent this. \n - \"Forbidden\": the anchor was created in a namespace that doesn't allow children, such as kube-system or hnc-system. The admission controller will attempt to prevent this."
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/charts/hnc/templates/NOTES.txt
+++ b/charts/hnc/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{ $.Chart.Name }} has been installed. 

--- a/charts/hnc/templates/_helpers.tpl
+++ b/charts/hnc/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "hnc.fullname" -}}
+  hnc
+{{- end }}
+{{- define "hnc.namespace" -}}
+  hnc-system
+{{- end -}}

--- a/charts/hnc/templates/hnc-admin-role.yaml
+++ b/charts/hnc/templates/hnc-admin-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: '{{ include "hnc.fullname" . }}-admin-role'
+rules:
+  - apiGroups:
+      - hnc.x-k8s.io
+    resources:
+      - '*'
+    verbs:
+      - '*'

--- a/charts/hnc/templates/hnc-controller-manager-ha.yaml
+++ b/charts/hnc/templates/hnc-controller-manager-ha.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.ha.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: {{ include "hnc.fullname" . }}-controller-manager-ha
+  namespace: {{ include "hnc.namespace" . }}
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      control-plane: controller-manager-ha
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      labels:
+        control-plane: controller-manager-ha
+    spec:
+      containers:
+        - args:
+            {{- if .Values.hrq.enabled }}
+            - --enable-hrq
+            {{- end }}
+            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}
+            - --excluded-namespace={{ $hncExcludeNamespace }}
+            {{- end }}
+            - --webhook-server-port=9443
+            - --metrics-addr=:8080
+            - --max-reconciles=10
+            - --apiserver-qps-throttle=50
+            - --nopropagation-label=cattle.io/creator=norman
+            - --webhooks-only
+          command:
+            - /manager
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default "hnc-manager:latest" }}
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /healthz
+              port: 8081
+            periodSeconds: 10
+          name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 8081
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 100
+            httpGet:
+              path: /readyz
+              port: 8081
+            periodSeconds: 5
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          {{- with .Values.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          {{- end }}
+          {{- with .Values.ha.manager.resources }}
+          resources: {{- toYaml . | nindent 12}}
+          {{- end }}
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ include "hnc.fullname" . }}-webhook-server-cert
+      {{- with .Values.ha.manager.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.ha.manager.affinity }}
+      affinity: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.ha.manager.tolerations }}
+      tolerations: {{- toYaml . | nindent 8}}
+      {{- end }}
+{{- end }}

--- a/charts/hnc/templates/hnc-controller-manager-metrics-service.yaml
+++ b/charts/hnc/templates/hnc-controller-manager-metrics-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
+  labels:
+    control-plane: controller-manager
+  name: '{{ include "hnc.fullname" . }}-controller-manager-metrics-service'
+  namespace: '{{ include "hnc.namespace" . }}'
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+  selector:
+    control-plane: controller-manager

--- a/charts/hnc/templates/hnc-controller-manager.yaml
+++ b/charts/hnc/templates/hnc-controller-manager.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: {{ include "hnc.fullname" . }}-controller-manager
+  namespace: {{ include "hnc.namespace" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            {{- if .Values.hrq.enabled }}
+            - --enable-hrq
+            {{- end }}
+            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}
+            - --excluded-namespace={{ $hncExcludeNamespace }}
+            {{- end }}
+            {{- if .Values.ha.enabled }}
+            - --no-webhooks
+            {{- end }}
+            - --webhook-server-port=9443
+            - --metrics-addr=:8080
+            - --max-reconciles=10
+            - --apiserver-qps-throttle=50
+            - --nopropagation-label=cattle.io/creator=norman
+            - --enable-internal-cert-management
+            - --cert-restart-on-secret-refresh
+          command:
+            - /manager
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default "hnc-manager:latest" }}
+          livenessProbe:
+            failureThreshold: 1
+            httpGet:
+              path: /healthz
+              port: 8081
+            periodSeconds: 10
+          name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 8081
+              name: healthz
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 100
+            httpGet:
+              path: /readyz
+              port: 8081
+            periodSeconds: 5
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+          {{- with .Values.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          {{- end }}
+          {{- with .Values.manager.resources }}
+          resources: {{- toYaml . | nindent 12}}
+          {{- end }}
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ include "hnc.fullname" . }}-webhook-server-cert
+      {{- with .Values.manager.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.manager.affinity }}
+      affinity: {{- toYaml . | nindent 8}}
+      {{- end }}
+      {{- with .Values.manager.tolerations }}
+      tolerations: {{- toYaml . | nindent 8}}
+      {{- end }}

--- a/charts/hnc/templates/hnc-leader-election-role.yaml
+++ b/charts/hnc/templates/hnc-leader-election-role.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: '{{ include "hnc.fullname" . }}-leader-election-role'
+  namespace: '{{ include "hnc.namespace" . }}'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create

--- a/charts/hnc/templates/hnc-leader-election-rolebinding.yaml
+++ b/charts/hnc/templates/hnc-leader-election-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ include "hnc.fullname" . }}-leader-election-rolebinding'
+  namespace: '{{ include "hnc.namespace" . }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "hnc.fullname" . }}-leader-election-role'
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: '{{ include "hnc.namespace" . }}'

--- a/charts/hnc/templates/hnc-manager-role.yaml
+++ b/charts/hnc/templates/hnc-manager-role.yaml
@@ -1,0 +1,73 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ include "hnc.fullname" . }}-manager-role'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotas
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - hnc.x-k8s.io
+    resources:
+      - hierarchicalresourcequotas
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - hnc.x-k8s.io
+    resources:
+      - hierarchicalresourcequotas/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - hnc.x-k8s.io
+    resources:
+      - hierarchies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - hnc.x-k8s.io
+    resources:
+      - hierarchies/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/charts/hnc/templates/hnc-manager-rolebinding.yaml
+++ b/charts/hnc/templates/hnc-manager-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: '{{ include "hnc.fullname" . }}-manager-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "hnc.fullname" . }}-manager-role'
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: '{{ include "hnc.namespace" . }}'

--- a/charts/hnc/templates/hnc-mutating-webhook-configuration.yaml
+++ b/charts/hnc/templates/hnc-mutating-webhook-configuration.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: '{{ include "hnc.fullname" . }}-mutating-webhook-configuration'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /mutate-namespace
+    failurePolicy: Ignore
+    name: namespacelabel.hnc.x-k8s.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - namespaces
+    sideEffects: None

--- a/charts/hnc/templates/hnc-validating-webhook-configuration.yaml
+++ b/charts/hnc/templates/hnc-validating-webhook-configuration.yaml
@@ -1,0 +1,157 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: '{{ include "hnc.fullname" . }}-validating-webhook-configuration'
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-hnc-x-k8s-io-v1alpha2-subnamespaceanchors
+    failurePolicy: Fail
+    name: subnamespaceanchors.hnc.x-k8s.io
+    rules:
+      - apiGroups:
+          - hnc.x-k8s.io
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - subnamespaceanchors
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-hnc-x-k8s-io-v1alpha2-hierarchyconfigurations
+    failurePolicy: Fail
+    name: hierarchyconfigurations.hnc.x-k8s.io
+    rules:
+      - apiGroups:
+          - hnc.x-k8s.io
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - hierarchyconfigurations
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-objects
+    failurePolicy: Fail
+    name: objects.hnc.x-k8s.io
+    namespaceSelector:
+      matchLabels:
+        hnc.x-k8s.io/included-namespace: "true"
+    rules:
+      - apiGroups:
+          - '*'
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - '*'
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 2
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-hnc-x-k8s-io-v1alpha2-hncconfigurations
+    failurePolicy: Fail
+    name: hncconfigurations.hnc.x-k8s.io
+    rules:
+      - apiGroups:
+          - hnc.x-k8s.io
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - hncconfigurations
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-v1-namespace
+    failurePolicy: Fail
+    name: namespaces.hnc.x-k8s.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - DELETE
+          - CREATE
+          - UPDATE
+        resources:
+          - namespaces
+    sideEffects: None
+  {{- if .Values.hrq.enabled }}
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-hnc-x-k8s-io-v1alpha2-hrq
+    failurePolicy: Fail
+    name: hrq.hnc.x-k8s.io
+    rules:
+    - apiGroups:
+      - hnc.x-k8s.io
+      apiVersions:
+      - v1alpha2
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - hierarchicalresourcequotas
+    sideEffects: None
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-hnc-x-k8s-io-v1alpha2-resourcequotasstatus
+    failurePolicy: Ignore
+    name: resourcesquotasstatus.hnc.x-k8s.io
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - UPDATE
+      resources:
+      - resourcequotas/status
+    sideEffects: None
+  {{- end }}

--- a/charts/hnc/templates/hnc-webhook-server-cert.yaml
+++ b/charts/hnc/templates/hnc-webhook-server-cert.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ include "hnc.fullname" . }}-webhook-server-cert'
+  namespace: '{{ include "hnc.namespace" . }}'

--- a/charts/hnc/templates/hnc-webhook-service.yaml
+++ b/charts/hnc/templates/hnc-webhook-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: '{{ include "hnc.fullname" . }}-webhook-service'
+  namespace: '{{ include "hnc.namespace" . }}'
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector: 
+    {{- if .Values.ha.enabled }}
+    control-plane: controller-manager-ha
+    {{- else }}
+    control-plane: controller-manager
+    {{- end }}

--- a/charts/hnc/values.yaml
+++ b/charts/hnc/values.yaml
@@ -1,0 +1,36 @@
+image:
+  repository: gcr.io/k8s-staging-multitenancy/hnc-manager
+  tag: v1.1.0
+  imagePullPolicy: {}
+# A list of namespaces to add the HNC exclude label to
+hncExcludeNamespaces:
+  - hnc-system
+  - kube-system
+  - kube-public
+  - kube-node-lease
+manager:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 300Mi
+    requests:
+      cpu: 100m
+      memory: 150Mi
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+hrq:
+  enabled: false
+ha:
+  enabled: false
+  manager:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 300Mi
+      requests:
+        cpu: 100m
+        memory: 150Mi
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []

--- a/docs/user-guide/how-to.md
+++ b/docs/user-guide/how-to.md
@@ -541,6 +541,32 @@ export HNC_IMG_TAG=test-img
 make deploy
 ```
 
+#### Install with Helm
+
+You can install HNC with Helm by following the instructions:
+
+Generate latest chart. 
+
+> _Note: This process should be done in [Automated Builds](../automated-builds.md)_
+
+```bash
+$ export HNC_REGISTRY=gcr.io/k8s-staging-multitenancy
+$ export HNC_IMG_NAME=hnc-manager
+$ export HNC_IMG_TAG=<HNC Version, eg v1.1.0>
+$ make charts
+```
+
+Install chart.
+You can do any setting in `charts/hnc/values.yaml` before installation.
+eg: setting hncExcludeNamespaces, enable HRQ, etc.
+
+> _Caution: Don't change release name(hnc) and namespace(hnc-system)
+> because HNC assumes them._
+
+```bash
+$ helm install hnc charts/hnc --create-namespace -n hnc-system
+```
+
 <a name="admin-uninstall"/>
 
 ### Uninstall HNC from a cluster

--- a/hack/helm_patches/NOTES.txt
+++ b/hack/helm_patches/NOTES.txt
@@ -1,0 +1,1 @@
+{{ $.Chart.Name }} has been installed. 

--- a/hack/helm_patches/_helpers.tpl
+++ b/hack/helm_patches/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "hnc.fullname" -}}
+  hnc
+{{- end }}
+{{- define "hnc.namespace" -}}
+  hnc-system
+{{- end -}}

--- a/hack/helm_patches/update-helm.sh
+++ b/hack/helm_patches/update-helm.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+ROOTDIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/../../"
+YQ=${ROOTDIR}/bin/yq
+MANIFESTDIR=${ROOTDIR}/manifests
+CAHRTDIR=${ROOTDIR}/charts/hnc
+TEMPLATESDIR=${CAHRTDIR}/templates
+
+# Remove CRDs templates from templates directory
+# CRDs templates have already been generated in the crds directory
+crd_files=$(ls ${CAHRTDIR}/crds/* | xargs -n 1 basename)
+for file in ${crd_files}; do
+    rm -f ${TEMPLATESDIR}/${file}
+done
+
+
+# [HRQ] Additional ValidatingWebhookConfiguration setting for HRQ
+# It will be added to default.yaml when HRQ is enabled by default near the future release.
+HRQWEBHOOK=$(
+cat <<'EOF'
+  {{- if .Values.hrq.enabled }}
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-hnc-x-k8s-io-v1alpha2-hrq
+    failurePolicy: Fail
+    name: hrq.hnc.x-k8s.io
+    rules:
+    - apiGroups:
+      - hnc.x-k8s.io
+      apiVersions:
+      - v1alpha2
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - hierarchicalresourcequotas
+    sideEffects: None
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: '{{ include "hnc.fullname" . }}-webhook-service'
+        namespace: '{{ include "hnc.namespace" . }}'
+        path: /validate-hnc-x-k8s-io-v1alpha2-resourcequotasstatus
+    failurePolicy: Ignore
+    name: resourcesquotasstatus.hnc.x-k8s.io
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - UPDATE
+      resources:
+      - resourcequotas/status
+    sideEffects: None
+  {{- end }}
+EOF
+)
+
+# Update templates
+for output_file in ${TEMPLATESDIR}/*.yaml; do
+  # Add prefix placeholder to Resource Name
+  if [ "$($YQ '.metadata | has("name")' $output_file)" = "true" ]; then
+    
+    resourcename=$($YQ -N '.metadata.name' $output_file | sed s/hnc-//g) $YQ -N -i '.metadata.name |= "{{ include \"hnc.fullname\" . }}-" + strenv(resourcename)' $output_file
+
+    # Add prefix placeholder to Service Name of WebhookConfiguration
+    if [ "$($YQ '.kind | (. == "*WebhookConfiguration")' $output_file)" = "true" ]; then
+      $YQ -N -i '.webhooks[].clientConfig.service.name |= "{{ include \"hnc.fullname\" . }}-webhook-service"' $output_file
+    fi
+  fi
+
+  # Replace Namespace Name with placeholder
+  if [ "$($YQ '.metadata | has("namespace")' $output_file)" = "true" ]; then
+    $YQ -N -i '.metadata.namespace |= "{{ include \"hnc.namespace\" . }}"' $output_file
+  fi
+  if [ "$($YQ '.kind | (. == "*WebhookConfiguration")' $output_file)" = "true" ]; then
+    $YQ -N -i '.webhooks[].clientConfig.service.namespace |= "{{ include \"hnc.namespace\" . }}"' $output_file
+  fi
+
+
+  # Update Deployment templates
+  if [ "$($YQ '.kind | (. == "Deployment")' $output_file)" = "true" ]; then
+    # Replace image name with placeholder
+    $YQ -N -i '(.spec.template.spec.containers[] | select(.name == "manager") | .image) |= "{{ .Values.image.repository }}:{{ .Values.image.tag | default \"hnc-manager:latest\" }}"' $output_file
+
+    # Add imagePullPolicy placeholder
+    $YQ -N -i '(.spec.template.spec.containers[] | select(.name == "manager") | .imagePullPolicy) |= "{{ .Values.image.imagePullPolicy }}"' $output_file
+
+    # Remove --excluded-namespace arg
+    # It will be replaced with placeholder later
+    $YQ -N -i 'del(.spec.template.spec.containers[] | select(.name=="manager").args[] | select(.=="--excluded-namespace=*"))' $output_file
+
+    # Replace resources with placeholder
+    $YQ -N -i 'del(.spec.template.spec.containers[] | select(.name=="manager") | .resources)' $output_file
+    $YQ -N -i '(.spec.template.spec.containers[] | select(.name=="manager") | .resources) |= "{{- toYaml . | nindent 12}}"' $output_file
+
+    # Add nodeSelector placeholder
+    $YQ -N -i '.spec.template.spec.nodeSelector |= "{{- toYaml . | nindent 8}}"' $output_file
+
+    # Add affinity placeholder
+    $YQ -N -i '.spec.template.spec.affinity |= "{{- toYaml . | nindent 8}}"' $output_file
+
+    # Add tolerations placeholder
+    $YQ -N -i '.spec.template.spec.tolerations |= "{{- toYaml . | nindent 8}}"' $output_file
+
+    # Add secretName placeholder
+    $YQ -N -i '(.spec.template.spec.volumes[] | select(.name == "cert") | .secret.secretName) |= "{{ include \"hnc.fullname\" . }}-webhook-server-cert"' $output_file
+
+    # Additional update for controller-manager Deployment
+    if [ "$($YQ '.metadata.name | (. == "*-controller-manager")' $output_file)" = "true" ]; then
+
+      # [HA] Add conditional blocks for --no-webhooks arg
+      sed -i -e '/args:/a \            {{- if .Values.ha.enabled }}\n \           - --no-webhooks\n \           {{- end }}' $output_file
+
+      # Add scope block for resources
+      sed -i -e 's/resources:/\{{- with .Values.manager.resources }}\n \         resources:/' $output_file
+      sed -i -e '/resources:/a \          {{- end }}' $output_file
+
+      # Add scope block for nodeSelector
+      sed -i -e 's/nodeSelector:/\{{- with .Values.manager.nodeSelector }}\n \     nodeSelector:/' $output_file
+      sed -i -e '/nodeSelector:/a \      {{- end }}' $output_file
+
+      # Add scope block for affinity
+      sed -i -e 's/affinity:/\{{- with .Values.manager.affinity }}\n \     affinity:/' $output_file
+      sed -i -e '/affinity:/a \      {{- end }}' $output_file
+
+      # Add scope block for tolerations
+      sed -i -e 's/tolerations:/\{{- with .Values.manager.tolerations }}\n \     tolerations:/' $output_file
+      sed -i -e '/tolerations:/a \      {{- end }}' $output_file
+
+    # [HA] Additional update for controller-manager-ha Deployment
+    elif [ "$($YQ '.metadata.name | (. == "*-controller-manager-ha")' $output_file)" = "true" ]; then
+
+      # [HA] Add scope block for resources
+      sed -i -e 's/resources:/\{{- with .Values.ha.manager.resources }}\n \         resources:/' $output_file
+      sed -i -e '/resources:/a \          {{- end }}' $output_file
+
+      # [HA] Add scope block for nodeSelector
+      sed -i -e 's/nodeSelector:/\{{- with .Values.ha.manager.nodeSelector }}\n \     nodeSelector:/' $output_file
+      sed -i -e '/nodeSelector:/a \      {{- end }}' $output_file
+
+      # [HA] Add scope block for affinity
+      sed -i -e 's/affinity:/\{{- with .Values.ha.manager.affinity }}\n \     affinity:/' $output_file
+      sed -i -e '/affinity:/a \      {{- end }}' $output_file
+
+      # [HA] Add scope block for tolerations
+      sed -i -e 's/tolerations:/\{{- with .Values.ha.manager.tolerations }}\n \     tolerations:/' $output_file
+      sed -i -e '/tolerations:/a \      {{- end }}' $output_file
+
+      # [HA] Add conditional blocks for controller-manager-ha Deployment
+      sed -i -e '1s/^/{{- if .Values.ha.enabled }}\n/g' $output_file
+      sed -i -e '$s/$/\n{{- end }}/g' $output_file
+
+    fi
+
+    # Add placeholder for --excluded-namespace arg
+    sed -i -e '/args:/a \            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}\n \           - --excluded-namespace={{ $hncExcludeNamespace }}\n \           {{- end }}' $output_file
+
+    # [HRQ] Add conditional blocks for --enable-hrq arg
+    sed -i -e '/args:/a \            {{- if .Values.hrq.enabled }}\n \           - --enable-hrq\n \           {{- end }}' $output_file
+
+    # Add conditional blocks for imagePullPolicy
+    sed -i -e 's/imagePullPolicy:/\{{- with .Values.imagePullPolicy }}\n \         imagePullPolicy:/' $output_file
+    sed -i -e '/imagePullPolicy:/a \          {{- end }}' $output_file
+
+    # Remove extra '' from templates
+    sed -i -e s/\'//g $output_file 
+
+  # Update RoleBinding template
+  elif [ "$($YQ '.kind | (. == "RoleBinding")' $output_file)" = "true" ]; then
+    if [ "$($YQ '.metadata.name | (. == "*-leader-election-rolebinding")' $output_file)" = "true" ]; then
+      $YQ -N -i '.roleRef.name |= "{{ include \"hnc.fullname\" . }}-leader-election-role"' $output_file
+      $YQ -N -i '(.subjects[] | select(.kind == "ServiceAccount") | .namespace) |= "{{ include \"hnc.namespace\" . }}"' $output_file
+    fi
+
+  # Update ClusterRoleBinding template
+  elif [ "$($YQ '.kind | (. == "ClusterRoleBinding")' $output_file)" = "true" ]; then
+    if [ "$($YQ '.metadata.name | (. == "*-manager-rolebinding")' $output_file)" = "true" ]; then
+      $YQ -N -i '.roleRef.name |= "{{ include \"hnc.fullname\" . }}-manager-role"' $output_file
+      $YQ -N -i '(.subjects[] | select(.kind == "ServiceAccount") | .namespace) |= "{{ include \"hnc.namespace\" . }}"' $output_file
+    fi
+
+  # [HA]Update Service templates for HA
+  # Add conditional blocks for selector
+  elif [ "$($YQ '.kind | (. == "Service")' $output_file)" = "true" ]; then
+    if [ "$($YQ '.metadata.name | (. == "*-webhook-service")' $output_file)" = "true" ]; then
+      $YQ -N -i 'del(.spec.selector)' $output_file
+      sed -i -e '$s/$/\n \ selector: \n  \  {{- if .Values.ha.enabled }}\n \   control-plane: controller-manager-ha\n \   {{- else }}\n \   control-plane: controller-manager\n \   {{- end }}/g' $output_file
+    fi
+
+  # [HRQ] Update ValidatingWebhookConfiguration template for HRQ
+  # It will be added to default.yaml when HRQ is enabled by default near the future release.
+  elif [ "$($YQ '.kind | (. == "ValidatingWebhookConfiguration")' $output_file)" = "true" ]; then
+    echo "$HRQWEBHOOK" >> "$output_file"
+  fi
+
+done


### PR DESCRIPTION
## What type of PR is this?:
/kind feature

## What this PR does / why we need it:
Provide HNC installation method via Helm.

Previously, it was disccussed in #46 and #62.
However, the problem that how to keep the chart up-to-date with changes in the config directory has not been resolved.
In this PR, I've added a mechanism to auto generate chart from manifest file generated from config directory using kustomize.

### How to use:

Clone this repository.

```console
$ git clone https://github.com/mochizuki875/hierarchical-namespaces.git -b feature_hnc_helm
```

Set environment variables.
They will be actually set in release process.

```console
$ export HNC_REGISTRY=gcr.io/k8s-staging-multitenancy
$ export HNC_IMG_NAME=hnc-manager
$ export HNC_IMG_TAG=<HNC Version, eg v1.1.0>
```

Generate chart.

```console
$ make charts
```

Install chart.
You can do any setting in `charts/hnc/values.yaml` before installation.
eg: setting hncExcludeNamespaces, enable HRQ, etc.

```console
$ cd charts/hnc
$ helm install hnc ./.  --create-namespace -n hnc-system
```

## Tested:
E2E tests has passed.

## Related:

#46
#62

## Special notes for your reviewer:
Packaging and publishing to chart repository are not included.
In many cases, charts are placed in gh-pages branch and published as Helm repository using GitHub Pages.

eg:  
https://github.com/prometheus-community/helm-charts/tree/gh-pages

Onece gh-pages branch is created add published as GitHub Pages, I think we can include these process in `cloudbuild.yaml`.