### PR TITLE
feat: kubectl-hns describe to show AllowCascadingDeletion flag

### DIFF
--- a/internal/kubectl/describe.go
+++ b/internal/kubectl/describe.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 )
@@ -73,6 +73,9 @@ var describeCmd = &cobra.Command{
 		} else {
 			fmt.Printf("  No children\n")
 		}
+
+		// AllowCascadingDeletion
+		fmt.Printf("  Allows Cascading Deletion: %t\n", hier.Spec.AllowCascadingDeletion)
 
 		// Conditions
 		describeConditions(hier.Status.Conditions)

--- a/test/e2e/quickstart_test.go
+++ b/test/e2e/quickstart_test.go
@@ -198,14 +198,14 @@ spec:
 		CreateSubnamespace(nsTeamB, nsOrg)
 
 		expected := "" + // empty string make go fmt happy
-		nsOrg + "\n" +
+			nsOrg + "\n" +
 			"├── [s] " + nsTeamA + "\n" +
 			"└── [s] " + nsTeamB
 		// The subnamespaces takes a bit of time to show up
 		RunShouldContain(expected, propogationTimeout, "kubectl hns tree", nsOrg)
 
 		// create hrq in parent acme-org
-		hrq:=`# quickstart_test.go: hrq in acme-org
+		hrq := `# quickstart_test.go: hrq in acme-org
 apiVersion: hnc.x-k8s.io/v1alpha2
 kind: HierarchicalResourceQuota
 metadata:
@@ -217,15 +217,15 @@ spec:
 		MustApplyYAML(hrq)
 
 		// create service in team-a
-		MustRun("kubectl create service clusterip", nsTeamA + "-svc", "--clusterip=None", "-n", nsTeamA)
+		MustRun("kubectl create service clusterip", nsTeamA+"-svc", "--clusterip=None", "-n", nsTeamA)
 
 		// show that you can't use resources more than the hrq
-		MustNotRun("kubectl create service clusterip", nsTeamB + "-svc", "--clusterip=None", "-n", nsTeamB)
+		MustNotRun("kubectl create service clusterip", nsTeamB+"-svc", "--clusterip=None", "-n", nsTeamB)
 
 		// show hrq usage
 		RunShouldContain("services: 1/1", defTimeout, "kubectl get hrq", "-n", nsOrg)
 
-		MustRun("kubectl delete hrq", nsOrg + "-hrq", "-n", nsOrg)
+		MustRun("kubectl delete hrq", nsOrg+"-hrq", "-n", nsOrg)
 	})
 
 	It("Should create and delete subnamespaces", func() {
@@ -268,6 +268,10 @@ spec:
 			nsTeamA + "\n" +
 			"└── [s] " + nsService2
 		RunShouldContain(expected, defTimeout, "kubectl hns tree", nsTeamA)
+
+		// Describe should describe AllowCascadingDeletion flag value
+		MustRun("kubectl hns describe", nsOrg)
+		RunShouldContain("Allows Cascading Deletion: false", defTimeout, "kubectl hns describe", nsOrg)
 
 		// cascading deletion with the kubectl-hns plugin
 		CreateSubnamespace(nsService1, nsTeamA)


### PR DESCRIPTION
Fixes Issues: #319 #303 

Enhances describe command in kubectl hns plugin to also show AllowCascadingDeletion flag.

```
$ kubectl hns describe boss                             
Hierarchy configuration for namespace boss
  Parent:  bigboss
  Children:
  - workers (subnamespace)
  Allows Cascading Deletion: true
  No conditions
```
*Tested:* Added test; verified that the test failed before the change and passed after it; ran e2e tests; also tested by hand on local cluster. 