### PR TITLE
Use dependabot to update go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "master"


### PR DESCRIPTION
Dependabot will automatically submit
pull requests for new versions of go
modules used by the project.

Documentation about using Dependabot
for version updates:

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates