### PR TITLE
feat: Parametrize number of replicas for HA deployment

### DIFF
--- a/charts/hnc/templates/hnc-controller-manager-ha.yaml
+++ b/charts/hnc/templates/hnc-controller-manager-ha.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "hnc.fullname" . }}-controller-manager-ha
   namespace: {{ include "hnc.namespace" . }}
 spec:
-  replicas: 3
+  replicas: {{ .Values.ha.manager.replicas }}
   selector:
     matchLabels:
       control-plane: controller-manager-ha

--- a/charts/hnc/values.yaml
+++ b/charts/hnc/values.yaml
@@ -24,6 +24,7 @@ hrq:
 ha:
   enabled: false
   manager:
+    replicas: 3
     resources:
       limits:
         cpu: 100m


### PR DESCRIPTION
For some deployments 3 replicas are a bit too much. Let's parametrize it.