### PR TITLE
feat(chart): create & mount service account

### DIFF
--- a/charts/hnc/Chart.yaml
+++ b/charts/hnc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hnc/templates/hnc-controller-manager.yaml
+++ b/charts/hnc/templates/hnc-controller-manager.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      serviceAccountName: {{ .Values.manager.serviceAccount }}
       containers:
         - args:
             {{- if .Values.hrq.enabled }}

--- a/charts/hnc/templates/hnc-leader-election-rolebinding.yaml
+++ b/charts/hnc/templates/hnc-leader-election-rolebinding.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: '{{ include "hnc.fullname" . }}-leader-election-role'
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: '{{ $.Values.manager.serviceAccount }}'
     namespace: '{{ include "hnc.namespace" . }}'

--- a/charts/hnc/templates/hnc-manager-rolebinding.yaml
+++ b/charts/hnc/templates/hnc-manager-rolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: '{{ include "hnc.fullname" . }}-manager-role'
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: "{{ $.Values.manager.serviceAccount }}"
     namespace: '{{ include "hnc.namespace" . }}'

--- a/charts/hnc/templates/hnc-manager-serviceaccount.yml
+++ b/charts/hnc/templates/hnc-manager-serviceaccount.yml
@@ -1,0 +1,7 @@
+{{- if ne .Values.manager.serviceAccount "default" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.manager.serviceAccount }}
+  namespace: hnc-system
+{{- end }}

--- a/charts/hnc/values.yaml
+++ b/charts/hnc/values.yaml
@@ -19,6 +19,8 @@ manager:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+
+  serviceAccount: default
 hrq:
   enabled: false
 ha:


### PR DESCRIPTION
this PR adds the ability to use / create a serviceAccount != "default" 

