### PR TITLE
exclude openshift namespaces via regex

### DIFF
--- a/charts/hnc/templates/hnc-admin.yaml
+++ b/charts/hnc/templates/hnc-admin.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: '{{ include "hnc.fullname" . }}-admin'
+rules:
+  - apiGroups:
+      - hnc.x-k8s.io
+    resources:
+      - hierarchicalresourcequotas
+      - subnamespaceanchors
+      - hierarchyconfigurations
+    verbs:
+      - '*'

--- a/charts/hnc/templates/hnc-controller-manager-ha.yaml
+++ b/charts/hnc/templates/hnc-controller-manager-ha.yaml
@@ -23,7 +23,10 @@ spec:
             {{- if .Values.hrq.enabled }}
             - --enable-hrq
             {{- end }}
-            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}
+            {{- if $hncIncludeNamespacesRegex }}
+            - --included-namespace-regex={{ $hncIncludeNamespacesRegex }}
+            {{- end }}
+            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces }}
             - --excluded-namespace={{ $hncExcludeNamespace }}
             {{- end }}
             - --webhook-server-port=9443

--- a/charts/hnc/templates/hnc-controller-manager.yaml
+++ b/charts/hnc/templates/hnc-controller-manager.yaml
@@ -22,7 +22,10 @@ spec:
             {{- if .Values.hrq.enabled }}
             - --enable-hrq
             {{- end }}
-            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}
+            {{- if $hncIncludeNamespacesRegex }}
+            - --included-namespace-regex={{ $hncIncludeNamespacesRegex }}
+            {{- end }}
+            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces }}
             - --excluded-namespace={{ $hncExcludeNamespace }}
             {{- end }}
             {{- if .Values.ha.enabled }}

--- a/charts/hnc/templates/hnc-edit.yaml
+++ b/charts/hnc/templates/hnc-edit.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: '{{ include "hnc.fullname" . }}-edit'
+rules:
+  - apiGroups:
+      - hnc.x-k8s.io
+    resources:
+      - hierarchicalresourcequotas
+      - subnamespaceanchors
+    verbs:
+      - '*'

--- a/charts/hnc/templates/hnc-resourcelist-apiextension.yaml
+++ b/charts/hnc/templates/hnc-resourcelist-apiextension.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: resourcelist-apiextension
+  name: {{ include "hnc.fullname" . }}-resourcelist-apiextension
+  namespace: {{ include "hnc.namespace" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: resourcelist-apiextension
+  template:
+    metadata:
+      labels:
+        app: resourcelist-apiextension
+    spec:
+      containers:
+        - args:
+            {{- if .Values.hrq.enabled }}
+            - --enable-hrq
+            {{- end }}
+            {{- if $hncIncludeNamespacesRegex }}
+            - --included-namespace-regex={{ $hncIncludeNamespacesRegex }}
+            {{- end }}
+            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces }}
+            - --excluded-namespace={{ $hncExcludeNamespace }}
+            {{- end }}
+            - --cert=/certs/tls.crt
+            - --key=/certs/tls.key
+          command:
+            - /apiextension
+          image: gcr.io/k8s-staging-multitenancy/hnc-manager:v1.1.0
+          {{- with .Values.imagePullPolicy }}
+          imagePullPolicy: IfNotPresent
+          {{- end }}
+          name: resourcelist
+          ports:
+            - containerPort: 7443
+              name: server
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /certs
+              name: certs
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      volumes:
+        - name: certs
+          secret:
+            defaultMode: 420
+            secretName: hnc-resourcelist-apiextension
+      nodeSelector: {{- toYaml . | nindent 8}}
+      affinity: {{- toYaml . | nindent 8}}
+      tolerations: {{- toYaml . | nindent 8}}

--- a/charts/hnc/templates/hnc-resourcelist.yaml
+++ b/charts/hnc/templates/hnc-resourcelist.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: resourcelist
+  name: '{{ include "hnc.fullname" . }}-resourcelist'
+  namespace: '{{ include "hnc.namespace" . }}'
+spec:
+  ports:
+    - port: 7443
+      protocol: TCP
+      targetPort: 7443
+  selector:
+    app: resourcelist

--- a/charts/hnc/templates/hnc-view.yaml
+++ b/charts/hnc/templates/hnc-view.yaml
@@ -2,12 +2,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  name: '{{ include "hnc.fullname" . }}-admin-role'
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: '{{ include "hnc.fullname" . }}-view'
 rules:
   - apiGroups:
       - hnc.x-k8s.io
     resources:
       - '*'
     verbs:
-      - '*'
+      - get
+      - list
+      - watch

--- a/charts/hnc/templates/v1alpha2.resources.hnc.x-k8s.io.yaml
+++ b/charts/hnc/templates/v1alpha2.resources.hnc.x-k8s.io.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: '{{ include "hnc.fullname" . }}-v1alpha2.resources.hnc.x-k8s.io'
+spec:
+  group: resources.hnc.x-k8s.io
+  groupPriorityMinimum: 10
+  service:
+    name: hnc-resourcelist
+    namespace: hnc-system
+    port: 7443
+  version: v1alpha2
+  versionPriority: 10

--- a/charts/hnc/values.yaml
+++ b/charts/hnc/values.yaml
@@ -2,6 +2,10 @@ image:
   repository: gcr.io/k8s-staging-multitenancy/hnc-manager
   tag: v1.1.0
   imagePullPolicy: {}
+# Regex of namespaces for HNC to manage
+# example include everything except openshift.*
+#hncIncludeNamespacesRegex: ([^o].*|o([^p].*)|op([^e].*)|ope([^n].*)|open([^s].*)|opens([^h].*)|opensh([^i].*)|openshi([^f].*)|openshif([^t].*))
+hncIncludeNamespacesRegex: ""
 # A list of namespaces to add the HNC exclude label to
 hncExcludeNamespaces:
   - hnc-system

--- a/hack/helm_patches/update-helm.sh
+++ b/hack/helm_patches/update-helm.sh
@@ -174,7 +174,10 @@ for output_file in ${TEMPLATESDIR}/*.yaml; do
     fi
 
     # Add placeholder for --excluded-namespace arg
-    sed -i -e '/args:/a \            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}\n \           - --excluded-namespace={{ $hncExcludeNamespace }}\n \           {{- end }}' $output_file
+    sed -i -e '/args:/a \            {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces }}\n \           - --excluded-namespace={{ $hncExcludeNamespace }}\n \           {{- end }}' $output_file
+
+    # Add placeholder for --included-namespace-regex arg
+    sed -i -e '/args:/a \            {{- if $hncIncludeNamespacesRegex }}\n \           - --included-namespace-regex={{ $hncIncludeNamespacesRegex }}\n \           {{- end }}' $output_file
 
     # [HRQ] Add conditional blocks for --enable-hrq arg
     sed -i -e '/args:/a \            {{- if .Values.hrq.enabled }}\n \           - --enable-hrq\n \           {{- end }}' $output_file


### PR DESCRIPTION
Adding `--included-namespace-regex` option to the helm chart.  
as mentioned [in the docs](https://github.com/kubernetes-sigs/hierarchical-namespaces/blob/master/docs/user-guide/how-to.md#including-and-excluding-namespaces-from-hnc) there is only `--included-namespace-regex` or `--excluded-namespace`.  
so in order to exclude all `openshift.*` namespaces I used the `--included-namespace-regex` as mentioned [in this issue](https://github.com/kubernetes-sigs/hierarchical-namespaces/issues/312), this is added as an example in `values.yaml`