### PR TITLE
feat: add chart values to manage labels and annotations

### DIFF
--- a/charts/hnc/templates/hnc-controller-manager-ha.yaml
+++ b/charts/hnc/templates/hnc-controller-manager-ha.yaml
@@ -23,6 +23,14 @@ spec:
             {{- if .Values.hrq.enabled }}
             - --enable-hrq
             {{- end }}
+            {{- range $hncManagedNamespaceLabel := .Values.hncManagedNamespaceLabels }}
+            - --managed-namespace-label
+            - {{ quote $hncManagedNamespaceLabel }}
+            {{- end }}
+            {{- range $hncManagedNamespaceAnnotation := .Values.hncManagedNamespaceAnnotations }}
+            - --managed-namespace-annotation
+            - {{ quote $hncManagedNamespaceAnnotation }}
+            {{- end }}
             {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}
             - --excluded-namespace={{ $hncExcludeNamespace }}
             {{- end }}

--- a/charts/hnc/templates/hnc-controller-manager.yaml
+++ b/charts/hnc/templates/hnc-controller-manager.yaml
@@ -22,6 +22,14 @@ spec:
             {{- if .Values.hrq.enabled }}
             - --enable-hrq
             {{- end }}
+            {{- range $hncManagedNamespaceLabel := .Values.hncManagedNamespaceLabels }}
+            - --managed-namespace-label
+            - {{ quote $hncManagedNamespaceLabel }}
+            {{- end }}
+            {{- range $hncManagedNamespaceAnnotation := .Values.hncManagedNamespaceAnnotations }}
+            - --managed-namespace-annotation
+            - {{ quote $hncManagedNamespaceAnnotation }}
+            {{- end }}
             {{- range $hncExcludeNamespace := .Values.hncExcludeNamespaces}}
             - --excluded-namespace={{ $hncExcludeNamespace }}
             {{- end }}

--- a/charts/hnc/values.yaml
+++ b/charts/hnc/values.yaml
@@ -8,6 +8,10 @@ hncExcludeNamespaces:
   - kube-system
   - kube-public
   - kube-node-lease
+# A list of regular expressions for namespace labels that HNC will manage
+hncManagedNamespaceLabels: []
+# A list of regular expressions for namespace annotations that HNC will manage
+hncManagedNamespaceAnnotations: []
 manager:
   resources:
     limits:


### PR DESCRIPTION
Without the ability to pass additional command-line arguments to the manager, installing HNC using a tool like ArgoCD requires developers to maintain their own fork.

This is a targetted PR relating to #385 for the special case of managed annotations and labels.

A separate PR could be used in lieu of this change, for passing any and all 'extraArgs' to the HNC controller that may be needed, now or in future. #387. I'll leave the choice of which to merge to the maintainers.