### PR TITLE
feat: extra args on manager

### DIFF
--- a/charts/hnc/templates/hnc-controller-manager-ha.yaml
+++ b/charts/hnc/templates/hnc-controller-manager-ha.yaml
@@ -32,6 +32,9 @@ spec:
             - --apiserver-qps-throttle=50
             - --nopropagation-label=cattle.io/creator=norman
             - --webhooks-only
+            {{- range $arg := .Values.manager.extraArgs }}
+            - {{ $arg }}
+            {{- end }}
           command:
             - /manager
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default "hnc-manager:latest" }}

--- a/charts/hnc/templates/hnc-controller-manager.yaml
+++ b/charts/hnc/templates/hnc-controller-manager.yaml
@@ -35,6 +35,9 @@ spec:
             - --nopropagation-label=cattle.io/creator=norman
             - --enable-internal-cert-management
             - --cert-restart-on-secret-refresh
+            {{- range $arg := .Values.manager.extraArgs }}
+            - {{ $arg }}
+            {{- end }}
           command:
             - /manager
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default "hnc-manager:latest" }}

--- a/charts/hnc/values.yaml
+++ b/charts/hnc/values.yaml
@@ -9,6 +9,7 @@ hncExcludeNamespaces:
   - kube-public
   - kube-node-lease
 manager:
+  extraArgs: []
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
Without the ability to pass additional command-line arguments to the manager, installing HNC using a tool like ArgoCD requires developers to maintain their own fork.

This PR is an alternative implementation that's closer to the spirit of #385, and mirrors pattterns used in other helm charts for passing extra arguments to commands.

Related to #386. Both could be merged, I guess, but this one is all that's absolutely necessary.

