### PR TITLE
Add Pod Annotations and Labels to Helm Chart

### DIFF
--- a/charts/hnc/templates/hnc-controller-manager-ha.yaml
+++ b/charts/hnc/templates/hnc-controller-manager-ha.yaml
@@ -15,8 +15,14 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
       labels:
         control-plane: controller-manager-ha
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
     spec:
       containers:
         - args:

--- a/charts/hnc/templates/hnc-controller-manager.yaml
+++ b/charts/hnc/templates/hnc-controller-manager.yaml
@@ -14,8 +14,14 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
       labels:
         control-plane: controller-manager
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
     spec:
       containers:
         - args:

--- a/charts/hnc/values.yaml
+++ b/charts/hnc/values.yaml
@@ -34,3 +34,5 @@ ha:
     nodeSelector: {}
     affinity: {}
     tolerations: []
+podAnnotations: {}
+podLabels: {}


### PR DESCRIPTION
This PR introduces support for adding custom annotations and labels to Pods created by the Helm chart. This enhancement provides better flexibility and allows for improved integration with external systems and workflows that rely on annotations or labels.

**Changes**:
	•	Added support for specifying Pod annotations in the `values.yaml` file.
	•	Added support for specifying Pod labels in the `values.yaml` file.
	•	Updated the `templates/hnc-controller-manager-ha.yaml` and `templates/hnc-controller-manager.yaml` files to include the provided annotations and labels.
	•	Verified changes to ensure backward compatibility when no annotations or labels are specified.

**Why this change is necessary:**
This change enhances the Helm chart’s configurability, enabling users to:
	•	Integrate with monitoring or logging tools that depend on specific annotations.
	•	Apply workload-specific metadata using labels for easier management and organization.