### PR TITLE
ci-test: bump K8S_VERSION to 1.26.1

### DIFF
--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -30,7 +30,7 @@ export PATH=$(go env GOPATH)/bin:$PATH
 mkdir -p $(go env GOPATH)/bin
 
 echo "Installing kubebuilder tools"
-K8S_VERSION=1.19.2
+K8S_VERSION=1.26.1
 curl -sSLo envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-${K8S_VERSION}-$(go env GOOS)-$(go env GOARCH).tar.gz"
 mkdir /usr/local/kubebuilder
 tar -C /usr/local/kubebuilder --strip-components=1 -zvxf envtest-bins.tar.gz


### PR DESCRIPTION
I'm not sure where this is used, but the K8S dependencies were updated to 1.26.x in commit 4b7fb70e. 